### PR TITLE
feat: compat go mod tidy

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -4,7 +4,7 @@ postRunCommand:
   - name: asdf install
     command: ./scripts/bootstrap-lib.sh; source .bootstrap/shell/lib/asdf.sh; asdf_install
   - name: go mod tidy
-    command: go mod tidy
+    command: go mod tidy -go=1.16 && go mod tidy -go=1.17
   - name: Format Files
     command: make gogenerate fmt
 arguments:


### PR DESCRIPTION
This PR modifies the post-run command to include the edgecase of when a dependency is resolved differently with Go 1.16 than the current version of Go (1.17) and enables it to properly be resolved.