### PR TITLE
fix(manifest): update name to match new stencil requirements

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -1,4 +1,4 @@
-name: stencil-base
+name: github.com/getoutreach/stencil-base
 modules: []
 postRunCommand:
   - name: asdf install


### PR DESCRIPTION
**What this PR does**: Updates the declared name to match the import path, which stencil now requires. This is purely a NOOP in current stencil versions, it's only used for extension repositories which this repository doesn't expose.