### PR TITLE
fix: release from the 'release' branch

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -8,10 +8,9 @@ postRunCommand:
   - name: Format Files
     command: make gogenerate fmt
 arguments:
-  name:
-    required: true
-    type: string
-    description: Name of the respository.
+  releaseOptions.enablePrereleases:
+    description: Enable prereleases
+    type: boolean
   description:
     required: true
     type: string

--- a/templates/.releaserc.yaml.tpl
+++ b/templates/.releaserc.yaml.tpl
@@ -1,10 +1,12 @@
+{{- $prereleases := stencil.Arg "releaseOptions.enablePrereleases" }}
 preset: conventionalcommits
 branches:
-  - name: master
-  - name: main
-{{- if (stencil.Arg "releaseOptions.allowPrereleases") }}
+{{- if $prereleases }}
+  - name: {{ .Git.DefaultBranch }}
+    prerelease: 'rc'
   - name: release
-    prerelease: true
+{{- else }}
+  - name: {{ .Git.DefaultBranch }}
 {{- end }}
 plugins:
   - - "@semantic-release/commit-analyzer"


### PR DESCRIPTION
This enables releasing from the `release` branch and using the default branch, usually `main`, as rc instead.