### PR TITLE
feat(runbooks): Add details and instructions to runbooks [EG-487]

### DIFF
--- a/templates/documentation/deployments.md.tpl
+++ b/templates/documentation/deployments.md.tpl
@@ -11,7 +11,7 @@
 
 ## Environments
 
-In order to inspect the deployments and pods associated with the {{ camelcase .Config.Name }} service you will first need to ensure the correct kubernetes context is set for the environment you intend to inspect.
+In order to inspect the deployments and pods associated with the {{ camelcase .Config.Name }} service you will first need to ensure the correct Kubernetes context is set for the environment you intend to inspect.
 
 You can set the appropriate Kubernetes context for the bento using `orc`:
 

--- a/templates/documentation/deployments.md.tpl
+++ b/templates/documentation/deployments.md.tpl
@@ -11,7 +11,7 @@
 
 ## Environments
 
-The {{ camelcase .Config.Name }} service is deployed to all bentos. In order to inspect the deployments and pods associated with the {{ camelcase .Config.Name }} service you will first need to ensure the correct kubernetes context is set for the environment you intend to inspect.
+In order to inspect the deployments and pods associated with the {{ camelcase .Config.Name }} service you will first need to ensure the correct kubernetes context is set for the environment you intend to inspect.
 
 You can set the appropriate Kubernetes context for the bento using `orc`:
 

--- a/templates/documentation/deployments.md.tpl
+++ b/templates/documentation/deployments.md.tpl
@@ -13,18 +13,13 @@
 
 The {{ camelcase .Config.Name }} service is deployed to all bentos. In order to inspect the deployments and pods associated with the {{ camelcase .Config.Name }} service you will first need to ensure the correct kubernetes context is set for the environment you intend to inspect.
 
-You can set the appropriate kubernetes context for the bento using the following mapping:
+You can set the appropriate Kubernetes context for the bento using `orc`:
 
-- dev environment:
-  - `kubectx dev-environment`
-- staging1a bento:
-  - `kubectx staging.us-east-2`
-- app1\* bentos:
-  - `kubectx production.us-west-2`
-- app2\* bentos:
-  - `kubectx production.us-east-1`
-- app4a bento:
-  - `kubectx app4a`
+```shell
+orc context <bento>
+```
+
+where `<bento>` is the bento name.
 
 <!--- Block(deploymentsEnvironments) -->
 {{ file.Block "deploymentsEnvironments" }}

--- a/templates/documentation/deployments.md.tpl
+++ b/templates/documentation/deployments.md.tpl
@@ -1,0 +1,35 @@
+{{- /* Only render markdown if forced, or if we're a service */}}
+{{- if not (or (stencil.Arg "forceRenderMarkdown") (stencil.Arg "service")) }}
+{{- file.Skip "project is not a service" }}
+{{- end }}
+<!-- Space: {{ stencil.Arg "opslevel.confluenceSpaceKey" }} -->
+<!-- Parent: Service Documentation 🧊 -->
+<!-- Parent: {{ .Config.Name }} 🧊 -->
+<!-- Title: {{ .Config.Name }} Deployments 🧊 -->
+
+# Deployments
+
+## Environments
+
+The {{ camelcase .Config.Name }} service is deployed to all bentos. In order to inspect the deployments and pods associated with the {{ camelcase .Config.Name }} service you will first need to ensure the correct kubernetes context is set for the environment you intend to inspect.
+
+You can set the appropriate kubernetes context for the bento using the following mapping:
+
+- dev environment:
+  - `kubectx dev-environment`
+- staging1a bento:
+  - `kubectx staging.us-east-2`
+- app1\* bentos:
+  - `kubectx production.us-west-2`
+- app2\* bentos:
+  - `kubectx production.us-east-1`
+- app4a bento:
+  - `kubectx app4a`
+
+<!--- Block(deploymentsEnvironments) -->
+{{ file.Block "deploymentsEnvironments" }}
+<!--- EndBlock(deploymentsEnvironments) -->
+
+<!--- Block(deployments) -->
+{{ file.Block "deployments" }}
+<!--- EndBlock(deployments) -->

--- a/templates/documentation/runbooks/available-pods-low.md.tpl
+++ b/templates/documentation/runbooks/available-pods-low.md.tpl
@@ -1,6 +1,7 @@
 {{- if not (stencil.Arg "service") }}
 {{- file.Skip "project is not a service" }}
 {{- end }}
+{{- $dashboard := stencil.Arg "datadogDashboards.mainLink" }}
 <!-- Space: {{ stencil.Arg "opslevel.confluenceSpaceKey" }} -->
 <!-- Parent: Service Documentation 🧊 -->
 <!-- Parent: {{ .Config.Name }} 🧊 -->

--- a/templates/documentation/runbooks/available-pods-low.md.tpl
+++ b/templates/documentation/runbooks/available-pods-low.md.tpl
@@ -65,7 +65,9 @@ Often times the historical state and logs are not easily accessible from within 
 
 Start by navigating to the {{ camelcase .Config.Name }} [service list in Komodor](https://app.komodor.com/main/services?textFilter={{ .Config.Name }}&filters=%7B%7D&tabType=service)
 
-From the main service list page select the bento that is alerting and view the pod status. You will likely want to inspect the pod details and logs:
+From the main service list page select the bento that is alerting and view the pod status. If the list of bentos is long you can filter the bentos by namespace to shorten the list of bentos and make it easier to identify the relevant bento deployment. As a reminder, Kubernetes namespaces, by convention, are formatted like `{{ .Config.Name }}--<bento>`, where `<bento>` is the bento name.
+
+You will likely want to inspect the pod details and logs:
 
 Once in the pod details page look for events or logs (both current and previous) that may provide clues to the root cause of the low number of running pods.
 

--- a/templates/documentation/runbooks/available-pods-low.md.tpl
+++ b/templates/documentation/runbooks/available-pods-low.md.tpl
@@ -48,13 +48,12 @@ kubectl -n {{ .Config.Name }}--<bento> describe deployment {{ .Config.Name }}
 
 ### Datadog Dashboard and Logs
 
-The {{ .Config.Name }} service has a dashboard in Datadog: https://app.datadoghq.com/dashboard/i6z-jcn-azh/terraform-{{ .Config.Name }}
+The {{ .Config.Name }} service has a [Datadog dashboard]({{ $dashboard }}). 
 
 Look for any anomalies in the dashboard.
 
-{{ camelcase .Config.Name }} logs are available via a search: https://app.datadoghq.com/logs/livetail?query=service%3A{{ .Config.Name }}%20environment%3Aproduction%20status%3Aerror&index=main&from_ts=1652033594145&to_ts=1652206394145&live=true. Modify the search parameters to match the bento and environment the alert was generated from.
-
-Look for signs of issues or abnormal behavior.
+To look for signs of issues or abnormal behavior in the logs, [navigate to Datadog](https://app.datadoghq.com/logs?query=service%3A{{ .Config.Name }}%20status%3Aerror) and
+add the `@deployment.bento:<bento>` facet, where `<bento>` is the bento that this alert fired in.
 
 <!--- Block(availablePodsLowDatadog) -->
 {{ file.Block "availablePodsLowDatadog" }}
@@ -64,7 +63,7 @@ Look for signs of issues or abnormal behavior.
 
 Often times the historical state and logs are not easily accessible from within the running cluster. If the logs from the crashed pod are not readily retrievable they may be archived in Komodor.
 
-Start by navigating to the {{ camelcase .Config.Name }} service list in Komodor: https://app.komodor.com/main/services?textFilter={{ .Config.Name }}&filters=%7B%7D&tabType=service
+Start by navigating to the {{ camelcase .Config.Name }} [service list in Komodor](https://app.komodor.com/main/services?textFilter={{ .Config.Name }}&filters=%7B%7D&tabType=service)
 
 From the main service list page select the bento that is alerting and view the pod status. You will likely want to inspect the pod details and logs:
 

--- a/templates/documentation/runbooks/available-pods-low.md.tpl
+++ b/templates/documentation/runbooks/available-pods-low.md.tpl
@@ -9,9 +9,9 @@
 
 # {{ camelcase .Config.Name }} Available Pods Low
 
-This alert triggers when most of the {{ camelcase .Config.Name }} pods have crashed or were otherwise terminated. During normal operation and with deployments it is expected that the pods will cycle regularly however the the kubernetes disruption budget should ensure that there is always a pool of pods available to service requests. When this alert triggers it is a sign that there are no longer enough pods running to ensure consistent service and if any more go down an outage may occur.
+This alert triggers when most of the {{ camelcase .Config.Name }} pods have crashed or were otherwise terminated. During normal operation and with deployments, it is expected that the pods will cycle regularly, however the the Kubernetes disruption budget should ensure that there is always a pool of pods available to service requests. When this alert triggers, it is a sign that there are no longer enough pods running to ensure consistent service and if any more go down, an outage may occur.
 
-If this alert is accompanied by [Pod Restarts](/documentation/runbooks/pod_restarts.md) Alerts it is possible that there is a critical issue causing the {{ camelcase .Config.Name }} service to repeatedly crash and immediate attention is required.
+If this alert is accompanied by [Pod Restarts](/documentation/runbooks/pod_restarts.md) alerts, it is possible that there is a critical issue causing the {{ camelcase .Config.Name }} service to repeatedly crash and immediate attention is required.
 
 <!--- Block(availablePodsLowOverview) -->
 {{ file.Block "availablePodsLowOverview" }}
@@ -21,7 +21,7 @@ If this alert is accompanied by [Pod Restarts](/documentation/runbooks/pod_resta
 
 ### Kubernetes Pod State
 
-Below are steps to follow to investigate the state of the kubernetes pods as well as look for potential reasons the number of running pods is low.
+Below are steps to follow to investigate the state of the Kubernetes pods as well as look for potential reasons the number of running pods is low.
 
 List the pods in the bento that the alert fired in for this service:
 
@@ -68,7 +68,7 @@ Start by navigating to the {{ camelcase .Config.Name }} service list in Komodor:
 
 From the main service list page select the bento that is alerting and view the pod status. You will likely want to inspect the pod details and logs:
 
-Once in the pod details page look for events or logs (both current and previous) that may provide clues to the root cause of the low number of running pods:
+Once in the pod details page look for events or logs (both current and previous) that may provide clues to the root cause of the low number of running pods.
 
 <!--- Block(availablePodsLowKomodor) -->
 {{ file.Block "availablePodsLowKomodor" }}

--- a/templates/documentation/runbooks/available-pods-low.md.tpl
+++ b/templates/documentation/runbooks/available-pods-low.md.tpl
@@ -9,6 +9,20 @@
 
 # {{ camelcase .Config.Name }} Available Pods Low
 
+This alert triggers when most of the {{ camelcase .Config.Name }} pods have crashed or were otherwise terminated. During normal operation and with deployments it is expected that the pods will cycle regularly however the the kubernetes disruption budget should ensure that there is always a pool of pods available to service requests. When this alert triggers it is a sign that there are no longer enough pods running to ensure consistent service and if any more go down an outage may occur.
+
+If this alert is accompanied by [Pod Restarts](/documentation/runbooks/pod_restarts.md) Alerts it is possible that there is a critical issue causing the {{ camelcase .Config.Name }} service to repeatedly crash and immediate attention is required.
+
+<!--- Block(availablePodsLowOverview) -->
+{{ file.Block "availablePodsLowOverview" }}
+<!--- EndBlock(availablePodsLowOverview) -->
+
+## Investigation
+
+### Kubernetes Pod State
+
+Below are steps to follow to investigate the state of the kubernetes pods as well as look for potential reasons the number of running pods is low.
+
 List the pods in the bento that the alert fired in for this service:
 
 ```shell
@@ -28,6 +42,48 @@ correct direction of the source of the problem. It may also be a useful exercise
 kubectl -n {{ .Config.Name }}--<bento> describe deployment {{ .Config.Name }}
 ```
 
-<!--- Block(availablePodsLow) -->
-{{ file.Block "availablePodsLow" }}
-<!--- EndBlock(availablePodsLow) -->
+<!--- Block(availablePodsLowPodState) -->
+{{ file.Block "availablePodsLowPodState" }}
+<!--- EndBlock(availablePodsLowPodState) -->
+
+### Datadog Dashboard and Logs
+
+The {{ .Config.Name }} service has a dashboard in Datadog: https://app.datadoghq.com/dashboard/i6z-jcn-azh/terraform-{{ .Config.Name }}
+
+Look for any anomalies in the dashboard.
+
+{{ camelcase .Config.Name }} logs are available via a search: https://app.datadoghq.com/logs/livetail?query=service%3A{{ .Config.Name }}%20environment%3Aproduction%20status%3Aerror&index=main&from_ts=1652033594145&to_ts=1652206394145&live=true. Modify the search parameters to match the bento and environment the alert was generated from.
+
+Look for signs of issues or abnormal behavior.
+
+<!--- Block(availablePodsLowDatadog) -->
+{{ file.Block "availablePodsLowDatadog" }}
+<!--- EndBlock(availablePodsLowDatadog) -->
+
+### Check Komodor for Pod State and Logs
+
+Often times the historical state and logs are not easily accessible from within the running cluster. If the logs from the crashed pod are not readily retrievable they may be archived in Komodor.
+
+Start by navigating to the {{ camelcase .Config.Name }} service list in Komodor: https://app.komodor.com/main/services?textFilter={{ .Config.Name }}&filters=%7B%7D&tabType=service
+
+From the main service list page select the bento that is alerting and view the pod status. You will likely want to inspect the pod details and logs:
+
+Once in the pod details page look for events or logs (both current and previous) that may provide clues to the root cause of the low number of running pods:
+
+<!--- Block(availablePodsLowKomodor) -->
+{{ file.Block "availablePodsLowKomodor" }}
+<!--- EndBlock(availablePodsLowKomodor) -->
+
+<!--- Block(availablePodsInvestigation) -->
+{{ file.Block "availablePodsInvestigation" }}
+<!--- EndBlock(availablePodsInvestigation) -->
+
+## Resolution
+
+<!--- Block(availablePodsLowResolution) -->
+{{ file.Block "availablePodsLowResolution" }}
+<!--- EndBlock(availablePodsLowResolution) -->
+
+<!--- Block(availablePodsLowExtra) -->
+{{ file.Block "availablePodsLowExtra" }}
+<!--- EndBlock(availablePodsLowExtra) -->

--- a/templates/documentation/runbooks/grpc-latency-high.md.tpl
+++ b/templates/documentation/runbooks/grpc-latency-high.md.tpl
@@ -2,6 +2,7 @@
 {{- if or (not (stencil.Arg "service")) (not $grpc) }}
 {{- file.Skip "project is not a service with grpc service activity" }}
 {{- end }}
+{{- $dashboard := stencil.Arg "datadogDashboards.mainLink" }}
 <!-- Space: {{ stencil.Arg "opslevel.confluenceSpaceKey" }} -->
 <!-- Parent: Service Documentation 🧊 -->
 <!-- Parent: {{ .Config.Name }} 🧊 -->

--- a/templates/documentation/runbooks/grpc-latency-high.md.tpl
+++ b/templates/documentation/runbooks/grpc-latency-high.md.tpl
@@ -20,7 +20,7 @@ This indicates that there are gRPC requests that are taking a long time to compl
 
 ### Honeycomb
 
-If there are a large volume of requests with high latencies some information on the details of the requests may be available in Honeycomb. Note that honeycomb samples requests (usually with a low sampling rate of 1%) so for low frequency issues the odds of finding something in Honeycomb are low.
+If there are a large volume of requests with high latencies some information on the details of the requests may be available in Honeycomb. Note that Honeycomb samples requests (usually with a low sampling rate of 1%), so for low frequency issues the odds of finding something specific in Honeycomb are low.
 
 [Navigate to Honeycomb](https://ui.honeycomb.io/outreach-a0/datasets/outreach?query=%7B%22time_range%22%3A7200%2C%22granularity%22%3A0%2C%22breakdowns%22%3A%5B%22name%22%5D%2C%22calculations%22%3A%5B%7B%22op%22%3A%22P95%22%2C%22column%22%3A%22duration_ms%22%7D%2C%7B%22op%22%3A%22HEATMAP%22%2C%22column%22%3A%22duration_ms%22%7D%5D%2C%22filters%22%3A%5B%7B%22column%22%3A%22app.name%22%2C%22op%22%3A%22%3D%22%2C%22value%22%3A%22{{ .Config.Name }}%22%7D%5D%2C%22filter_combination%22%3A%22AND%22%2C%22orders%22%3A%5B%7B%22column%22%3A%22duration_ms%22%2C%22op%22%3A%22P95%22%2C%22order%22%3A%22descending%22%7D%5D%2C%22havings%22%3A%5B%5D%2C%22limit%22%3A1000%7D) 
 and add `deployment.namespace = {{ .Config.Name }}--<bento>` to the `WHERE` clause, where `<bento>` is the bento that
@@ -32,13 +32,12 @@ this alert fired in. These traces should provide an idea as to what could be the
 
 ### Datadog Dashboard and Logs
 
-The {{ .Config.Name }} service has a dashboard in Datadog: https://app.datadoghq.com/dashboard/i6z-jcn-azh/terraform-{{ .Config.Name }}
+The {{ .Config.Name }} service has a [Datadog dashboard]({{ $dashboard }}). 
 
 Look for any anomalies in the dashboard.
 
-{{ camelcase .Config.Name }} logs are available via a search: https://app.datadoghq.com/logs/livetail?query=service%3A{{ .Config.Name }}%20environment%3Aproduction%20status%3Aerror&index=main&from_ts=1652033594145&to_ts=1652206394145&live=true. Modify the search parameters to match the bento and environment the alert was generated from.
-
-Look for signs of issues or abnormal behavior.
+To look for signs of issues or abnormal behavior in the logs, [navigate to Datadog](https://app.datadoghq.com/logs?query=service%3A{{ .Config.Name }}%20status%3Aerror) and
+add the `@deployment.bento:<bento>` facet, where `<bento>` is the bento that this alert fired in.
 
 <!--- Block(grpcLatencyHighDatadog) -->
 {{ file.Block "grpcLatencyHighDatadog" }}

--- a/templates/documentation/runbooks/grpc-latency-high.md.tpl
+++ b/templates/documentation/runbooks/grpc-latency-high.md.tpl
@@ -12,10 +12,49 @@
 
 This indicates that there are gRPC requests that are taking a long time to complete.
 
+<!--- Block(grpcLatencyHighOverview) -->
+{{ file.Block "grpcLatencyHighOverview" }}
+<!--- EndBlock(grpcLatencyHighOverview) -->
+
+## Investigation
+
+### Honeycomb
+
+If there are a large volume of requests with high latencies some information on the details of the requests may be available in Honeycomb. Note that honeycomb samples requests (usually with a low sampling rate of 1%) so for low frequency issues the odds of finding something in Honeycomb are low.
+
 [Navigate to Honeycomb](https://ui.honeycomb.io/outreach-a0/datasets/outreach?query=%7B%22time_range%22%3A7200%2C%22granularity%22%3A0%2C%22breakdowns%22%3A%5B%22name%22%5D%2C%22calculations%22%3A%5B%7B%22op%22%3A%22P95%22%2C%22column%22%3A%22duration_ms%22%7D%2C%7B%22op%22%3A%22HEATMAP%22%2C%22column%22%3A%22duration_ms%22%7D%5D%2C%22filters%22%3A%5B%7B%22column%22%3A%22app.name%22%2C%22op%22%3A%22%3D%22%2C%22value%22%3A%22{{ .Config.Name }}%22%7D%5D%2C%22filter_combination%22%3A%22AND%22%2C%22orders%22%3A%5B%7B%22column%22%3A%22duration_ms%22%2C%22op%22%3A%22P95%22%2C%22order%22%3A%22descending%22%7D%5D%2C%22havings%22%3A%5B%5D%2C%22limit%22%3A1000%7D) 
 and add `deployment.namespace = {{ .Config.Name }}--<bento>` to the `WHERE` clause, where `<bento>` is the bento that
 this alert fired in. These traces should provide an idea as to what could be the root cause of the latency.
 
-<!--- Block(grpcLatencyHigh) -->
-{{ file.Block "grpcLatencyHigh" }}
-<!--- EndBlock(grpcLatencyHigh) -->
+<!--- Block(grpcLatencyHighHoneycomb)) -->
+{{ file.Block "grpcLatencyHighHoneycomb)" }}
+<!--- EndBlock(grpcLatencyHighHoneycomb)) -->
+
+### Datadog Dashboard and Logs
+
+The {{ .Config.Name }} service has a dashboard in Datadog: https://app.datadoghq.com/dashboard/i6z-jcn-azh/terraform-{{ .Config.Name }}
+
+Look for any anomalies in the dashboard.
+
+{{ camelcase .Config.Name }} logs are available via a search: https://app.datadoghq.com/logs/livetail?query=service%3A{{ .Config.Name }}%20environment%3Aproduction%20status%3Aerror&index=main&from_ts=1652033594145&to_ts=1652206394145&live=true. Modify the search parameters to match the bento and environment the alert was generated from.
+
+Look for signs of issues or abnormal behavior.
+
+<!--- Block(grpcLatencyHighDatadog) -->
+{{ file.Block "grpcLatencyHighDatadog" }}
+<!--- EndBlock(grpcLatencyHighDatadog) -->
+
+
+<!--- Block(grpcLatencyHighInvestigation)) -->
+{{ file.Block "grpcLatencyHighInvestigation)" }}
+<!--- EndBlock(grpcLatencyHighInvestigation)) -->
+
+## Resolution
+
+<!--- Block(grpcLatencyHighResolution) -->
+{{ file.Block "grpcLatencyHighResolution" }}
+<!--- EndBlock(grpcLatencyHighResolution) -->
+
+<!--- Block(grpcLatencyHighExtra)) -->
+{{ file.Block "grpcLatencyHighExtra)" }}
+<!--- EndBlock(grpcLatencyHighExtra)) -->

--- a/templates/documentation/runbooks/grpc-success-rate-low.md.tpl
+++ b/templates/documentation/runbooks/grpc-success-rate-low.md.tpl
@@ -20,7 +20,7 @@ This indicates that there are gRPC requests that are returning unintended server
 
 ### Honeycomb
 
-If there are a large volume of requests with errors some information on the details of the requests may be available in Honeycomb. Note that honeycomb samples requests (usually with a low sampling rate of 1%) so for low frequency issues the odds of finding something specific in Honeycomb are low.
+If there are a large volume of requests with errors some information on the details of the requests may be available in Honeycomb. Note that Honeycomb samples requests (usually with a low sampling rate of 1%) so for low frequency issues the odds of finding something specific in Honeycomb are low.
 
 [Navigate to Honeycomb](https://ui.honeycomb.io/outreach-a0/datasets/outreach?query=%7B%22time_range%22%3A7200%2C%22granularity%22%3A0%2C%22breakdowns%22%3A%5B%22name%22%5D%2C%22calculations%22%3A%5B%7B%22op%22%3A%22P95%22%2C%22column%22%3A%22duration_ms%22%7D%2C%7B%22op%22%3A%22HEATMAP%22%2C%22column%22%3A%22duration_ms%22%7D%5D%2C%22filters%22%3A%5B%7B%22column%22%3A%22app.name%22%2C%22op%22%3A%22%3D%22%2C%22value%22%3A%22{{ .Config.Name }}%22%7D%5D%2C%22filter_combination%22%3A%22AND%22%2C%22orders%22%3A%5B%7B%22column%22%3A%22duration_ms%22%2C%22op%22%3A%22P95%22%2C%22order%22%3A%22descending%22%7D%5D%2C%22havings%22%3A%5B%5D%2C%22limit%22%3A1000%7D) 
 and add `deployment.namespace = {{ .Config.Name }}--<bento>` to the `WHERE` clause, where `<bento>` is the bento that

--- a/templates/documentation/runbooks/grpc-success-rate-low.md.tpl
+++ b/templates/documentation/runbooks/grpc-success-rate-low.md.tpl
@@ -2,6 +2,7 @@
 {{- if or (not (stencil.Arg "service")) (not $grpc) }}
 {{- file.Skip "project is not a service with grpc service activity" }}
 {{- end }}
+{{- $dashboard := stencil.Arg "datadogDashboards.mainLink" }}
 <!-- Space: {{ stencil.Arg "opslevel.confluenceSpaceKey" }} -->
 <!-- Parent: Service Documentation 🧊 -->
 <!-- Parent: {{ .Config.Name }} 🧊 -->
@@ -20,7 +21,7 @@ This indicates that there are gRPC requests that are returning unintended server
 
 ### Honeycomb
 
-If there are a large volume of requests with errors some information on the details of the requests may be available in Honeycomb. Note that Honeycomb samples requests (usually with a low sampling rate of 1%) so for low frequency issues the odds of finding something specific in Honeycomb are low.
+If there are a large volume of requests with errors some information on the details of the requests may be available in Honeycomb. Note that honeycomb samples requests (usually with a low sampling rate of 1%) so for low frequency issues the odds of finding something specific in Honeycomb are low.
 
 [Navigate to Honeycomb](https://ui.honeycomb.io/outreach-a0/datasets/outreach?query=%7B%22time_range%22%3A7200%2C%22granularity%22%3A0%2C%22breakdowns%22%3A%5B%22name%22%5D%2C%22calculations%22%3A%5B%7B%22op%22%3A%22P95%22%2C%22column%22%3A%22duration_ms%22%7D%2C%7B%22op%22%3A%22HEATMAP%22%2C%22column%22%3A%22duration_ms%22%7D%5D%2C%22filters%22%3A%5B%7B%22column%22%3A%22app.name%22%2C%22op%22%3A%22%3D%22%2C%22value%22%3A%22{{ .Config.Name }}%22%7D%5D%2C%22filter_combination%22%3A%22AND%22%2C%22orders%22%3A%5B%7B%22column%22%3A%22duration_ms%22%2C%22op%22%3A%22P95%22%2C%22order%22%3A%22descending%22%7D%5D%2C%22havings%22%3A%5B%5D%2C%22limit%22%3A1000%7D) 
 and add `deployment.namespace = {{ .Config.Name }}--<bento>` to the `WHERE` clause, where `<bento>` is the bento that

--- a/templates/documentation/runbooks/grpc-success-rate-low.md.tpl
+++ b/templates/documentation/runbooks/grpc-success-rate-low.md.tpl
@@ -55,9 +55,9 @@ Once you determine what the errors are, they usually fall into one of several ca
 
 1. Errors that should not generate a gRPC error. If this is the case, create a Jira ticket and optionally fix the log entries so that they won’t be counted when generating alerts. Until the log entries are fixed, success rate low errors will continue to be triggered.
 
-2. Error that are genuinely server errors. These errors occur for various reasons:
+2. Errors that are genuinely server errors. These occur for various reasons:
 
-   - Code that is generating gRPC errors because of an unexpected case (example: nil pointer exceptio. If it's code, create a Jira and optionally fix the code.
+   - Code that is generating gRPC errors because of an unexpected case (example: nil pointer exception). If it's code, create a Jira and optionally fix the code.
 
    - Service errors because of lack of resources, etc. Follow the instructions in the [Pod Restarts](/documentation/runbooks/pod_restarts.md) runbook if you suspect memory issues need investigation.
 

--- a/templates/documentation/runbooks/grpc-success-rate-low.md.tpl
+++ b/templates/documentation/runbooks/grpc-success-rate-low.md.tpl
@@ -12,10 +12,59 @@
 
 This indicates that there are gRPC requests that are returning unintended server errors.
 
-[Navigate to Datadog](https://app.datadoghq.com/logs?query=service%3A{{ .Config.Name }}%20status%3Aerror) and
-add the `@deployment.bento:<bento>` facet, where `<bento>` is the bento that this alert fired in. These logs
-should provide an idea as to what could be the root cause of gRPC calls resulting in server-level errors.
+<!--- Block(grpcSuccessRateLowOverview) -->
+{{ file.Block "grpcSuccessRateLowOverview" }}
+<!--- EndBlock(grpcSuccessRateLowOverview) -->
 
-<!--- Block(grpcSuccessRateLow) -->
-{{ file.Block "grpcSuccessRateLow" }}
-<!--- EndBlock(grpcSuccessRateLow) -->
+## Investigation
+
+### Honeycomb
+
+If there are a large volume of requests with errors some information on the details of the requests may be available in Honeycomb. Note that honeycomb samples requests (usually with a low sampling rate of 1%) so for low frequency issues the odds of finding something in Honeycomb are low.
+
+[Navigate to Honeycomb](https://ui.honeycomb.io/outreach-a0/datasets/outreach?query=%7B%22time_range%22%3A7200%2C%22granularity%22%3A0%2C%22breakdowns%22%3A%5B%22name%22%5D%2C%22calculations%22%3A%5B%7B%22op%22%3A%22P95%22%2C%22column%22%3A%22duration_ms%22%7D%2C%7B%22op%22%3A%22HEATMAP%22%2C%22column%22%3A%22duration_ms%22%7D%5D%2C%22filters%22%3A%5B%7B%22column%22%3A%22app.name%22%2C%22op%22%3A%22%3D%22%2C%22value%22%3A%22{{ .Config.Name }}%22%7D%5D%2C%22filter_combination%22%3A%22AND%22%2C%22orders%22%3A%5B%7B%22column%22%3A%22duration_ms%22%2C%22op%22%3A%22P95%22%2C%22order%22%3A%22descending%22%7D%5D%2C%22havings%22%3A%5B%5D%2C%22limit%22%3A1000%7D) 
+and add `deployment.namespace = {{ .Config.Name }}--<bento>` to the `WHERE` clause, where `<bento>` is the bento that
+this alert fired in. These traces may provide an idea as to what could be the root cause of the errors.
+
+<!--- Block(grpcSuccessRateLowHoneycomb)) -->
+{{ file.Block "grpcSuccessRateLowHoneycomb)" }}
+<!--- EndBlock(grpcSuccessRateLowHoneycomb)) -->
+
+### Datadog Dashboard and Logs
+
+The {{ .Config.Name }} service has a dashboard in Datadog: https://app.datadoghq.com/dashboard/i6z-jcn-azh/terraform-{{ .Config.Name }}
+
+Look for any anomalies in the dashboard.
+
+{{ camelcase .Config.Name }} logs are available via a search: https://app.datadoghq.com/logs/livetail?query=service%3A{{ .Config.Name }}%20environment%3Aproduction%20status%3Aerror&index=main&from_ts=1652033594145&to_ts=1652206394145&live=true. Modify the search parameters to match the bento and environment the alert was generated from.
+
+Look for signs of issues or abnormal behavior.
+
+<!--- Block(grpcSuccessRateLowDatadog) -->
+{{ file.Block "grpcSuccessRateLowDatadog" }}
+<!--- EndBlock(grpcSuccessRateLowDatadog) -->
+
+
+<!--- Block(grpcSuccessRateLowInvestigation)) -->
+{{ file.Block "grpcSuccessRateLowInvestigation)" }}
+<!--- EndBlock(grpcSuccessRateLowInvestigation)) -->
+
+## Resolution
+
+Once you determine what the errors are, they usually fall into one of several categories:
+
+1. Errors that should not generate a gRPC error. If this is the case, create a Jira ticket and optionally fix the log entries so that they won’t be counted when generating alerts. Until the log entries are fixed, success rate low errors will continue to be triggered.
+
+2. Error that are genuinely server errors. These errors occur for various reasons:
+
+   - Code that is generating gRPC errors because of an unexpected case (example: nil pointer exceptio. If it's code, create a Jira and optionally fix the code.
+
+   - Service errors because of lack of resources, etc. Follow the instructions in the [Pod Restarts](/documentation/runbooks/pod_restarts.md) runbook if you suspect memory issues need investigation.
+
+<!--- Block(grpcSuccessRateLowResolution) -->
+{{ file.Block "grpcSuccessRateLowResolution" }}
+<!--- EndBlock(grpcSuccessRateLowResolution) -->
+
+<!--- Block(grpcSuccessRateLowExtra) -->
+{{ file.Block "grpcSuccessRateLowExtra" }}
+<!--- EndBlock(grpcSuccessRateLowExtra) -->

--- a/templates/documentation/runbooks/grpc-success-rate-low.md.tpl
+++ b/templates/documentation/runbooks/grpc-success-rate-low.md.tpl
@@ -20,7 +20,7 @@ This indicates that there are gRPC requests that are returning unintended server
 
 ### Honeycomb
 
-If there are a large volume of requests with errors some information on the details of the requests may be available in Honeycomb. Note that honeycomb samples requests (usually with a low sampling rate of 1%) so for low frequency issues the odds of finding something in Honeycomb are low.
+If there are a large volume of requests with errors some information on the details of the requests may be available in Honeycomb. Note that honeycomb samples requests (usually with a low sampling rate of 1%) so for low frequency issues the odds of finding something specific in Honeycomb are low.
 
 [Navigate to Honeycomb](https://ui.honeycomb.io/outreach-a0/datasets/outreach?query=%7B%22time_range%22%3A7200%2C%22granularity%22%3A0%2C%22breakdowns%22%3A%5B%22name%22%5D%2C%22calculations%22%3A%5B%7B%22op%22%3A%22P95%22%2C%22column%22%3A%22duration_ms%22%7D%2C%7B%22op%22%3A%22HEATMAP%22%2C%22column%22%3A%22duration_ms%22%7D%5D%2C%22filters%22%3A%5B%7B%22column%22%3A%22app.name%22%2C%22op%22%3A%22%3D%22%2C%22value%22%3A%22{{ .Config.Name }}%22%7D%5D%2C%22filter_combination%22%3A%22AND%22%2C%22orders%22%3A%5B%7B%22column%22%3A%22duration_ms%22%2C%22op%22%3A%22P95%22%2C%22order%22%3A%22descending%22%7D%5D%2C%22havings%22%3A%5B%5D%2C%22limit%22%3A1000%7D) 
 and add `deployment.namespace = {{ .Config.Name }}--<bento>` to the `WHERE` clause, where `<bento>` is the bento that
@@ -32,13 +32,12 @@ this alert fired in. These traces may provide an idea as to what could be the ro
 
 ### Datadog Dashboard and Logs
 
-The {{ .Config.Name }} service has a dashboard in Datadog: https://app.datadoghq.com/dashboard/i6z-jcn-azh/terraform-{{ .Config.Name }}
+The {{ .Config.Name }} service has a [Datadog dashboard]({{ $dashboard }}). 
 
 Look for any anomalies in the dashboard.
 
-{{ camelcase .Config.Name }} logs are available via a search: https://app.datadoghq.com/logs/livetail?query=service%3A{{ .Config.Name }}%20environment%3Aproduction%20status%3Aerror&index=main&from_ts=1652033594145&to_ts=1652206394145&live=true. Modify the search parameters to match the bento and environment the alert was generated from.
-
-Look for signs of issues or abnormal behavior.
+To look for signs of issues or abnormal behavior in the logs, [navigate to Datadog](https://app.datadoghq.com/logs?query=service%3A{{ .Config.Name }}%20status%3Aerror) and
+add the `@deployment.bento:<bento>` facet, where `<bento>` is the bento that this alert fired in.
 
 <!--- Block(grpcSuccessRateLowDatadog) -->
 {{ file.Block "grpcSuccessRateLowDatadog" }}

--- a/templates/documentation/runbooks/http-latency-high.md.tpl
+++ b/templates/documentation/runbooks/http-latency-high.md.tpl
@@ -12,9 +12,44 @@
 
 This indicates that there are HTTP requests that are taking a long time to complete.
 
+## Investigation
+
+### Datadog Dashboard and Logs
+
+The {{ .Config.Name }} service has a dashboard in Datadog: https://app.datadoghq.com/dashboard/i6z-jcn-azh/terraform-{{ .Config.Name }}
+
+Look for any anomalies in the dashboard.
+
+{{ camelcase .Config.Name }} logs are available via a search: https://app.datadoghq.com/logs/livetail?query=service%3A{{ .Config.Name }}%20environment%3Aproduction%20status%3Aerror&index=main&from_ts=1652033594145&to_ts=1652206394145&live=true. Modify the search parameters to match the bento and environment the alert was generated from.
+
+Look for signs of issues or abnormal behavior.
+
+<!--- Block(httpLatencyHighDatadog) -->
+{{ file.Block "httpLatencyHighDatadog" }}
+<!--- EndBlock(httpLatencyHighDatadog) -->
+
+### Honeycomb
+
+If there are a large volume of requests with errors some information on the details of the requests may be available in Honeycomb. Note that honeycomb samples requests (usually with a low sampling rate of 1%) so for low frequency issues the odds of finding something in Honeycomb are low.
+
 [Navigate to Honeycomb](https://ui.honeycomb.io/outreach-a0/datasets/outreach?query=%7B%22time_range%22%3A7200%2C%22granularity%22%3A0%2C%22breakdowns%22%3A%5B%22name%22%5D%2C%22calculations%22%3A%5B%7B%22op%22%3A%22P95%22%2C%22column%22%3A%22duration_ms%22%7D%2C%7B%22op%22%3A%22HEATMAP%22%2C%22column%22%3A%22duration_ms%22%7D%5D%2C%22filters%22%3A%5B%7B%22column%22%3A%22app.name%22%2C%22op%22%3A%22%3D%22%2C%22value%22%3A%22{{ .Config.Name }}%22%7D%5D%2C%22filter_combination%22%3A%22AND%22%2C%22orders%22%3A%5B%7B%22column%22%3A%22duration_ms%22%2C%22op%22%3A%22P95%22%2C%22order%22%3A%22descending%22%7D%5D%2C%22havings%22%3A%5B%5D%2C%22limit%22%3A1000%7D) 
 and add `deployment.namespace = {{ .Config.Name }}--<bento>` to the `WHERE` clause, where `<bento>` is the bento that
 this alert fired in. These traces should provide an idea as to what could be the root cause of the latency.
+
+<!--- Block(httpLatencyHighHoneycomb)) -->
+{{ file.Block "httpLatencyHighHoneycomb)" }}
+<!--- EndBlock(httpLatencyHighHoneycomb)) -->
+
+
+<!--- Block(httpLatencyHighInvestigation)) -->
+{{ file.Block "httpLatencyHighInvestigation)" }}
+<!--- EndBlock(httpLatencyHighInvestigation)) -->
+
+## Resolution
+
+<!--- Block(httpLatencyHighResolution) -->
+{{ file.Block "httpLatencyHighResolution" }}
+<!--- EndBlock(httpLatencyHighResolution) -->
 
 <!--- Block(httpLatencyHigh) -->
 {{ file.Block "httpLatencyHigh" }}

--- a/templates/documentation/runbooks/http-latency-high.md.tpl
+++ b/templates/documentation/runbooks/http-latency-high.md.tpl
@@ -16,13 +16,12 @@ This indicates that there are HTTP requests that are taking a long time to compl
 
 ### Datadog Dashboard and Logs
 
-The {{ .Config.Name }} service has a dashboard in Datadog: https://app.datadoghq.com/dashboard/i6z-jcn-azh/terraform-{{ .Config.Name }}
+The {{ .Config.Name }} service has a [Datadog dashboard]({{ $dashboard }}). 
 
 Look for any anomalies in the dashboard.
 
-{{ camelcase .Config.Name }} logs are available via a search: https://app.datadoghq.com/logs/livetail?query=service%3A{{ .Config.Name }}%20environment%3Aproduction%20status%3Aerror&index=main&from_ts=1652033594145&to_ts=1652206394145&live=true. Modify the search parameters to match the bento and environment the alert was generated from.
-
-Look for signs of issues or abnormal behavior.
+To look for signs of issues or abnormal behavior in the logs, [navigate to Datadog](https://app.datadoghq.com/logs?query=service%3A{{ .Config.Name }}%20status%3Aerror) and
+add the `@deployment.bento:<bento>` facet, where `<bento>` is the bento that this alert fired in.
 
 <!--- Block(httpLatencyHighDatadog) -->
 {{ file.Block "httpLatencyHighDatadog" }}
@@ -30,7 +29,7 @@ Look for signs of issues or abnormal behavior.
 
 ### Honeycomb
 
-If there are a large volume of requests with errors some information on the details of the requests may be available in Honeycomb. Note that honeycomb samples requests (usually with a low sampling rate of 1%) so for low frequency issues the odds of finding something in Honeycomb are low.
+If there are a large volume of requests with high latency some information on the details of the requests may be available in Honeycomb. Note that Honeycomb samples requests (usually with a low sampling rate of 1%) so for low frequency issues the odds of finding something specific in Honeycomb are low.
 
 [Navigate to Honeycomb](https://ui.honeycomb.io/outreach-a0/datasets/outreach?query=%7B%22time_range%22%3A7200%2C%22granularity%22%3A0%2C%22breakdowns%22%3A%5B%22name%22%5D%2C%22calculations%22%3A%5B%7B%22op%22%3A%22P95%22%2C%22column%22%3A%22duration_ms%22%7D%2C%7B%22op%22%3A%22HEATMAP%22%2C%22column%22%3A%22duration_ms%22%7D%5D%2C%22filters%22%3A%5B%7B%22column%22%3A%22app.name%22%2C%22op%22%3A%22%3D%22%2C%22value%22%3A%22{{ .Config.Name }}%22%7D%5D%2C%22filter_combination%22%3A%22AND%22%2C%22orders%22%3A%5B%7B%22column%22%3A%22duration_ms%22%2C%22op%22%3A%22P95%22%2C%22order%22%3A%22descending%22%7D%5D%2C%22havings%22%3A%5B%5D%2C%22limit%22%3A1000%7D) 
 and add `deployment.namespace = {{ .Config.Name }}--<bento>` to the `WHERE` clause, where `<bento>` is the bento that

--- a/templates/documentation/runbooks/http-latency-high.md.tpl
+++ b/templates/documentation/runbooks/http-latency-high.md.tpl
@@ -2,6 +2,7 @@
 {{- if or (not (stencil.Arg "service")) (not $http) }}
 {{- file.Skip "project is not a service with http service activity" }}
 {{- end }}
+{{- $dashboard := stencil.Arg "datadogDashboards.mainLink" }}
 <!-- Space: {{ stencil.Arg "opslevel.confluenceSpaceKey" }} -->
 <!-- Parent: Service Documentation 🧊 -->
 <!-- Parent: {{ .Config.Name }} 🧊 -->

--- a/templates/documentation/runbooks/http-success-rate-low.md.tpl
+++ b/templates/documentation/runbooks/http-success-rate-low.md.tpl
@@ -16,7 +16,7 @@ This indicates that there are HTTP requests that are returning unintended server
 
 ### Datadog Dashboard and Logs
 
-The {{ .Config.Name }} service has a dashboard in Datadog: https://app.datadoghq.com/dashboard/i6z-jcn-azh/terraform-{{ .Config.Name }}
+The {{ .Config.Name }} service has a [Datadog dashboard]({{ $dashboard }}). 
 
 Look for any anomalies in the dashboard.
 
@@ -30,7 +30,7 @@ should provide an idea as to what could be the root cause of HTTP calls resultin
 
 ### Honeycomb
 
-If there are a large volume of requests with errors some information on the details of the requests may be available in Honeycomb. Note that honeycomb samples requests (usually with a low sampling rate of 1%) so for low frequency issues the odds of finding something in Honeycomb are low.
+If there are a large volume of requests with errors some information on the details of the requests may be available in Honeycomb. Note that honeycomb samples requests (usually with a low sampling rate of 1%) so for low frequency issues the odds of finding something specific in Honeycomb are low.
 
 [Navigate to Honeycomb](https://ui.honeycomb.io/outreach-a0/datasets/outreach?query=%7B%22time_range%22%3A7200%2C%22granularity%22%3A0%2C%22breakdowns%22%3A%5B%22name%22%5D%2C%22calculations%22%3A%5B%7B%22op%22%3A%22P95%22%2C%22column%22%3A%22duration_ms%22%7D%2C%7B%22op%22%3A%22HEATMAP%22%2C%22column%22%3A%22duration_ms%22%7D%5D%2C%22filters%22%3A%5B%7B%22column%22%3A%22app.name%22%2C%22op%22%3A%22%3D%22%2C%22value%22%3A%22{{ .Config.Name }}%22%7D%5D%2C%22filter_combination%22%3A%22AND%22%2C%22orders%22%3A%5B%7B%22column%22%3A%22duration_ms%22%2C%22op%22%3A%22P95%22%2C%22order%22%3A%22descending%22%7D%5D%2C%22havings%22%3A%5B%5D%2C%22limit%22%3A1000%7D) 
 and add `deployment.namespace = {{ .Config.Name }}--<bento>` to the `WHERE` clause, where `<bento>` is the bento that

--- a/templates/documentation/runbooks/http-success-rate-low.md.tpl
+++ b/templates/documentation/runbooks/http-success-rate-low.md.tpl
@@ -12,9 +12,43 @@
 
 This indicates that there are HTTP requests that are returning unintended server errors.
 
+## Investigation
+
+### Datadog Dashboard and Logs
+
+The {{ .Config.Name }} service has a dashboard in Datadog: https://app.datadoghq.com/dashboard/i6z-jcn-azh/terraform-{{ .Config.Name }}
+
+Look for any anomalies in the dashboard.
+
 [Navigate to Datadog](https://app.datadoghq.com/logs?query=service%3A{{ .Config.Name }}%20status%3Aerror) and
 add the `@deployment.bento:<bento>` facet, where `<bento>` is the bento that this alert fired in. These logs
 should provide an idea as to what could be the root cause of HTTP calls resulting in server-level errors.
+
+<!--- Block(httpSuccessRateLowDatadog) -->
+{{ file.Block "httpSuccessRateLowDatadog" }}
+<!--- EndBlock(httpSuccessRateLowDatadog) -->
+
+### Honeycomb
+
+If there are a large volume of requests with errors some information on the details of the requests may be available in Honeycomb. Note that honeycomb samples requests (usually with a low sampling rate of 1%) so for low frequency issues the odds of finding something in Honeycomb are low.
+
+[Navigate to Honeycomb](https://ui.honeycomb.io/outreach-a0/datasets/outreach?query=%7B%22time_range%22%3A7200%2C%22granularity%22%3A0%2C%22breakdowns%22%3A%5B%22name%22%5D%2C%22calculations%22%3A%5B%7B%22op%22%3A%22P95%22%2C%22column%22%3A%22duration_ms%22%7D%2C%7B%22op%22%3A%22HEATMAP%22%2C%22column%22%3A%22duration_ms%22%7D%5D%2C%22filters%22%3A%5B%7B%22column%22%3A%22app.name%22%2C%22op%22%3A%22%3D%22%2C%22value%22%3A%22{{ .Config.Name }}%22%7D%5D%2C%22filter_combination%22%3A%22AND%22%2C%22orders%22%3A%5B%7B%22column%22%3A%22duration_ms%22%2C%22op%22%3A%22P95%22%2C%22order%22%3A%22descending%22%7D%5D%2C%22havings%22%3A%5B%5D%2C%22limit%22%3A1000%7D) 
+and add `deployment.namespace = {{ .Config.Name }}--<bento>` to the `WHERE` clause, where `<bento>` is the bento that
+this alert fired in. These traces should provide an idea as to what could be the root cause of the latency.
+
+<!--- Block(httpSuccessRateLowHoneycomb)) -->
+{{ file.Block "httpSuccessRateLowHoneycomb)" }}
+<!--- EndBlock(httpSuccessRateLowHoneycomb)) -->
+
+<!--- Block(httpSuccessRateLowInvestigation) -->
+{{ file.Block "httpSuccessRateLowInvestigation" }}
+<!--- EndBlock(httpSuccessRateLowInvestigation) -->
+
+## Resolution
+
+<!--- Block(httpSuccessRateLowResolution) -->
+{{ file.Block "httpSuccessRateLowResolution" }}
+<!--- EndBlock(httpSuccessRateLowResolution) -->
 
 <!--- Block(httpSuccessRateLow) -->
 {{ file.Block "httpSuccessRateLow" }}

--- a/templates/documentation/runbooks/http-success-rate-low.md.tpl
+++ b/templates/documentation/runbooks/http-success-rate-low.md.tpl
@@ -2,6 +2,7 @@
 {{- if or (not (stencil.Arg "service")) (not $http) }}
 {{- file.Skip "project is not a service with http service activity" }}
 {{- end }}
+{{- $dashboard := stencil.Arg "datadogDashboards.mainLink" }}
 <!-- Space: {{ stencil.Arg "opslevel.confluenceSpaceKey" }} -->
 <!-- Parent: Service Documentation 🧊 -->
 <!-- Parent: {{ .Config.Name }} 🧊 -->

--- a/templates/documentation/runbooks/pod-cpu.md.tpl
+++ b/templates/documentation/runbooks/pod-cpu.md.tpl
@@ -28,9 +28,8 @@ various sources of traffic like gRPC or HTTP. Looking at logs at the same time f
 
 Look for any anomalies in the dashboard.
 
-{{ camelcase .Config.Name }} logs are available via a search: https://app.datadoghq.com/logs/livetail?query=service%3A{{ .Config.Name }}%20environment%3Aproduction%20status%3Aerror&index=main&from_ts=1652033594145&to_ts=1652206394145&live=true. Modify the search parameters to match the bento and environment the alert was generated from.
-
-Look for signs of issues or abnormal behavior.
+To look for signs of issues or abnormal behavior in the logs, [navigate to Datadog](https://app.datadoghq.com/logs?query=service%3A{{ .Config.Name }}%20status%3Aerror) and
+add the `@deployment.bento:<bento>` facet, where `<bento>` is the bento that this alert fired in.
 
 <!--- Block(podCPUSpikeDatadog) -->
 {{ file.Block "podCPUSpikeDatadog" }}
@@ -38,7 +37,7 @@ Look for signs of issues or abnormal behavior.
 
 ### Honeycomb
 
-If there are a large volume of requests with triggering the issue some information on the details of the requests may be available in Honeycomb. Note that honeycomb samples requests (usually with a low sampling rate of 1%) so for low frequency issues the odds of finding something in Honeycomb are low.
+If there are a large volume of requests that trigger the issue some information on the details of the requests may be available in Honeycomb. Note that Honeycomb samples requests (usually with a low sampling rate of 1%) so for low frequency issues the odds of finding something specific in Honeycomb are low.
 
 You can use the following as a starter Honeycomb query to begin looking for traces that exhibit the performance problems you are investigating.
 

--- a/templates/documentation/runbooks/pod-cpu.md.tpl
+++ b/templates/documentation/runbooks/pod-cpu.md.tpl
@@ -10,11 +10,65 @@
 
 # {{ camelcase .Config.Name }} Pod CPU > \<threshold\>% of request last \<window\>m
 
+CPU high alerts will occur if the CPU rate is too high over x amount of time. The net impact is that customers might start seeing failures in {{ camelcase .Config.Name }} requests. On the other hand, none of the above might actually happen and the CPU usage might drop down on it’s own. If the High CPU usage keeps repeating for the same host, there might be something wrong with the host itself and it might need recycling - all of this is described in much more detail below.
+
+<!--- Block(podCPUSpikeOverview) -->
+{{ file.Block "podCPUSpikeOverview" }}
+<!--- EndBlock(podCPUSpikeOverview) -->
+
+## Investigation
+
+### Datadog Dashboard and Logs
+
 [Navigate to the `Terraform: {{ camelcase .Config.Name }}` dashboard]({{ $dashboard }}) and find the "Total CPU" monitor under
 the "Deployment" pane. Zero-in on a time frame where CPU spiked, note that time frame, and change the window of
 the dashboard to that time frame. Correlate any other useful monitors to see what could be causing this - look at
 various sources of traffic like gRPC or HTTP. Looking at logs at the same time frame may also be useful using the
 `kube_namespace:{{ .Config.Name }}--<bento>` facet.
+
+Look for any anomalies in the dashboard.
+
+{{ camelcase .Config.Name }} logs are available via a search: https://app.datadoghq.com/logs/livetail?query=service%3A{{ .Config.Name }}%20environment%3Aproduction%20status%3Aerror&index=main&from_ts=1652033594145&to_ts=1652206394145&live=true. Modify the search parameters to match the bento and environment the alert was generated from.
+
+Look for signs of issues or abnormal behavior.
+
+<!--- Block(podCPUSpikeDatadog) -->
+{{ file.Block "podCPUSpikeDatadog" }}
+<!--- EndBlock(podCPUSpikeDatadog) -->
+
+### Honeycomb
+
+If there are a large volume of requests with triggering the issue some information on the details of the requests may be available in Honeycomb. Note that honeycomb samples requests (usually with a low sampling rate of 1%) so for low frequency issues the odds of finding something in Honeycomb are low.
+
+You can use the following as a starter Honeycomb query to begin looking for traces that exhibit the performance problems you are investigating.
+
+<!--- Block(ggrpcSuccessRateLowHoneycomb)) -->
+{{ file.Block "grpcSuccessRateLowHoneycomb)" }}
+<!--- EndBlock(grpcSuccessRateLowHoneycomb)) -->
+
+### Check the Pod CPU Usage Directly
+
+You can get a real time view of current CPU utilization in the cluster by running the following command:
+
+`kubectl --context <context> -n {{ .Config.Name }}--<bento> top pod`
+
+Substitute the appropriate values for `<context>` and `<bento>` based on the environment and bento you want to modify. Refer to [Deployments](/documentation/deployments.md) for a mapping from bento to context.
+
+The output of the top command will show the current CPU and memory usage for all of the pods running in the cluster. Look for pods with abnormally high values. You can view the logs for specific pods with the following command:
+
+`kubectl --context <context> -n {{ .Config.Name }}--<bento> log <pod_name>`
+
+where `<pod_name>` is the name of the pod exhibiting abnormal CPU usage.
+
+<!--- Block(podCPUSpikeDirect) -->
+{{ file.Block "podCPUSpikeDirect" }}
+<!--- EndBlock(podCPUSpikeDirect) -->
+
+## Resolution
+
+<!--- Block(podCPUSpikeResolution) -->
+{{ file.Block "podCPUSpikeResolution" }}
+<!--- EndBlock(podCPUSpikeResolution) -->
 
 <!--- Block(podCPUSpike) -->
 {{ file.Block "podCPUSpike" }}

--- a/templates/documentation/runbooks/pod-cpu.md.tpl
+++ b/templates/documentation/runbooks/pod-cpu.md.tpl
@@ -10,7 +10,7 @@
 
 # {{ camelcase .Config.Name }} Pod CPU > \<threshold\>% of request last \<window\>m
 
-CPU high alerts will occur if the CPU rate is too high over x amount of time. The net impact is that customers might start seeing failures in {{ camelcase .Config.Name }} requests. On the other hand, none of the above might actually happen and the CPU usage might drop down on it’s own. If the High CPU usage keeps repeating for the same host, there might be something wrong with the host itself and it might need recycling - all of this is described in much more detail below.
+CPU high alerts will occur if the CPU rate is too high over x amount of time. The net impact is that customers might start seeing failures in {{ camelcase .Config.Name }} requests. On the other hand, none of the above might actually happen and the CPU usage might drop down on its own. If the High CPU usage keeps repeating for the same host, there might be something wrong with the host itself and it might need recycling - all of this is described in much more detail below.
 
 <!--- Block(podCPUSpikeOverview) -->
 {{ file.Block "podCPUSpikeOverview" }}
@@ -50,13 +50,17 @@ You can use the following as a starter Honeycomb query to begin looking for trac
 
 You can get a real time view of current CPU utilization in the cluster by running the following command:
 
-`kubectl --context <context> -n {{ .Config.Name }}--<bento> top pod`
+```shell
+kubectl --context <context> -n {{ .Config.Name }}--<bento> top pod
+```
 
 Substitute the appropriate values for `<context>` and `<bento>` based on the environment and bento you want to modify. Refer to [Deployments](/documentation/deployments.md) for a mapping from bento to context.
 
 The output of the top command will show the current CPU and memory usage for all of the pods running in the cluster. Look for pods with abnormally high values. You can view the logs for specific pods with the following command:
 
-`kubectl --context <context> -n {{ .Config.Name }}--<bento> log <pod_name>`
+```shell
+kubectl --context <context> -n {{ .Config.Name }}--<bento> log <pod_name>
+```
 
 where `<pod_name>` is the name of the pod exhibiting abnormal CPU usage.
 

--- a/templates/documentation/runbooks/pod-memory.md.tpl
+++ b/templates/documentation/runbooks/pod-memory.md.tpl
@@ -22,9 +22,10 @@ the dashboard to that time frame. Correlate any other useful monitors to see wha
 various sources of traffic like gRPC or HTTP. Looking at logs at the same time frame may also be useful using the
 `kube_namespace:{{ .Config.Name }}--<bento>` facet.
 
-Also look at the [trending memory dashboard](https://app.datadoghq.com/dashboard/i6z-jcn-azh/terraform-{{ .Config.Name }}?fullscreen_end_ts=1642528770105&fullscreen_paused=false&fullscreen_section=overview&fullscreen_start_ts=1641923970105&fullscreen_widget=5625648833266685&from_ts=1641923966020&to_ts=1642528766020&live=true) in DataDog.
+Also look at the trending memory widget in the dashboard to look for patterns or timing that can be correlated with service activity.
 
-Additional {{ camelcase .Config.Name }} logs are available via a search: https://app.datadoghq.com/logs/livetail?query=service%3A{{ .Config.Name }}%20environment%3Aproduction%20status%3Aerror&index=main&from_ts=1652033594145&to_ts=1652206394145&live=true. Modify the search parameters to match the bento and environment the alert was generated from.
+To look for signs of issues or abnormal behavior in the logs, [navigate to Datadog](https://app.datadoghq.com/logs?query=service%3A{{ .Config.Name }}%20status%3Aerror) and
+add the `@deployment.bento:<bento>` facet, where `<bento>` is the bento that this alert fired in.
 
 <!--- Block(podMemorySpikeDatadog) -->
 {{ file.Block "podMemorySpikeDatadog" }}
@@ -32,7 +33,7 @@ Additional {{ camelcase .Config.Name }} logs are available via a search: https:/
 
 ### Honeycomb
 
-If there are a large volume of requests with triggering the issue some information on the details of the requests may be available in Honeycomb. Note that honeycomb samples requests (usually with a low sampling rate of 1%) so for low frequency issues the odds of finding something in Honeycomb are low.
+If there are a large volume of requests that trigger the issue some information on the details of the requests may be available in Honeycomb. Note that Honeycomb samples requests (usually with a low sampling rate of 1%) so for low frequency issues the odds of finding something specific in Honeycomb are low.
 
 [Navigate to Honeycomb](https://ui.honeycomb.io/outreach-a0/datasets/outreach?query=%7B%22time_range%22%3A7200%2C%22granularity%22%3A0%2C%22breakdowns%22%3A%5B%22name%22%5D%2C%22calculations%22%3A%5B%7B%22op%22%3A%22P95%22%2C%22column%22%3A%22duration_ms%22%7D%2C%7B%22op%22%3A%22HEATMAP%22%2C%22column%22%3A%22duration_ms%22%7D%5D%2C%22filters%22%3A%5B%7B%22column%22%3A%22app.name%22%2C%22op%22%3A%22%3D%22%2C%22value%22%3A%22{{ .Config.Name }}%22%7D%5D%2C%22filter_combination%22%3A%22AND%22%2C%22orders%22%3A%5B%7B%22column%22%3A%22duration_ms%22%2C%22op%22%3A%22P95%22%2C%22order%22%3A%22descending%22%7D%5D%2C%22havings%22%3A%5B%5D%2C%22limit%22%3A1000%7D) 
 and add `deployment.namespace = {{ .Config.Name }}--<bento>` to the `WHERE` clause, where `<bento>` is the bento that

--- a/templates/documentation/runbooks/pod-memory.md.tpl
+++ b/templates/documentation/runbooks/pod-memory.md.tpl
@@ -10,7 +10,7 @@
 
 # {{ camelcase .Config.Name }} Pod Memory.\<type\> > 80% of limit last 30m
 
-Memory high alerts will occur if the memory rate is too high over x amount of time. The net impact is that customers might start seeing failures in {{ camelcase .Config.Name }} requests. On the other hand, none of the above might actually happen and the memory usage might drop down on it’s own. If the High Memory usage keeps repeating for the same host, there might be something wrong with the host itself and it might need recycling - all of this is described in much more detail below.
+Memory high alerts will occur if the memory rate is too high over x amount of time. The net impact is that customers might start seeing failures in {{ camelcase .Config.Name }} requests. On the other hand, none of the above might actually happen and the memory usage might drop down on its own. If the High Memory usage keeps repeating for the same host, there might be something wrong with the host itself and it might need recycling - all of this is described in much more detail below.
 
 ## Investigation
 
@@ -50,13 +50,17 @@ Once you determine what the errors are, they fall usually fall into one of sever
 
 2. Hardware error: The solution is to restart the pod. The simplest way to due this is by triggering a new deployment with:
 
-`kubectl --context <context> -n {{ .Config.Name }}--<bento> patch deployment {{ .Config.Name }} -p "{\"spec\": {\"template\": {\"metadata\": { \"labels\": { \"redeploy\": \"$(date +%s)\"}}}}}"`
+```shell
+kubectl --context <context> -n {{ .Config.Name }}--<bento> patch deployment {{ .Config.Name }} -p "{\"spec\": {\"template\": {\"metadata\": { \"labels\": { \"redeploy\": \"$(date +%s)\"}}}}}"
+```
 
 Substitute the appropriate values for `<context>` and `<bento>` based on the environment and bento you want to modify. Refer to [Deployments](/documentation/deployments.md) for a mapping from bento to context.
 
 Verify the pods are cycling by executing:
 
-`kubectl --context <context> -n {{ .Config.Name }}--<bento> get pods`
+```shell
+kubectl --context <context> -n {{ .Config.Name }}--<bento> get pods
+```
 
 and verifying the pods are restarting, or recently restarted.
 

--- a/templates/documentation/runbooks/pod-memory.md.tpl
+++ b/templates/documentation/runbooks/pod-memory.md.tpl
@@ -10,11 +10,59 @@
 
 # {{ camelcase .Config.Name }} Pod Memory.\<type\> > 80% of limit last 30m
 
+Memory high alerts will occur if the memory rate is too high over x amount of time. The net impact is that customers might start seeing failures in {{ camelcase .Config.Name }} requests. On the other hand, none of the above might actually happen and the memory usage might drop down on it’s own. If the High Memory usage keeps repeating for the same host, there might be something wrong with the host itself and it might need recycling - all of this is described in much more detail below.
+
+## Investigation
+
+### Datadog Dashboard and Logs
+
 [Navigate to the `Terraform: {{ camelcase .Config.Name }}` dashboard]({{ $dashboard }}) and find the "Total Memory" monitor under
 the "Deployment" pane. Zero-in on a time frame where memory spiked, note that time frame, and change the window of
 the dashboard to that time frame. Correlate any other useful monitors to see what could be causing this - look at
 various sources of traffic like gRPC or HTTP. Looking at logs at the same time frame may also be useful using the
 `kube_namespace:{{ .Config.Name }}--<bento>` facet.
+
+Also look at the [trending memory dashboard](https://app.datadoghq.com/dashboard/i6z-jcn-azh/terraform-{{ .Config.Name }}?fullscreen_end_ts=1642528770105&fullscreen_paused=false&fullscreen_section=overview&fullscreen_start_ts=1641923970105&fullscreen_widget=5625648833266685&from_ts=1641923966020&to_ts=1642528766020&live=true) in DataDog.
+
+Additional {{ camelcase .Config.Name }} logs are available via a search: https://app.datadoghq.com/logs/livetail?query=service%3A{{ .Config.Name }}%20environment%3Aproduction%20status%3Aerror&index=main&from_ts=1652033594145&to_ts=1652206394145&live=true. Modify the search parameters to match the bento and environment the alert was generated from.
+
+<!--- Block(podMemorySpikeDatadog) -->
+{{ file.Block "podMemorySpikeDatadog" }}
+<!--- EndBlock(podMemorySpikeDatadog) -->
+
+### Honeycomb
+
+If there are a large volume of requests with triggering the issue some information on the details of the requests may be available in Honeycomb. Note that honeycomb samples requests (usually with a low sampling rate of 1%) so for low frequency issues the odds of finding something in Honeycomb are low.
+
+[Navigate to Honeycomb](https://ui.honeycomb.io/outreach-a0/datasets/outreach?query=%7B%22time_range%22%3A7200%2C%22granularity%22%3A0%2C%22breakdowns%22%3A%5B%22name%22%5D%2C%22calculations%22%3A%5B%7B%22op%22%3A%22P95%22%2C%22column%22%3A%22duration_ms%22%7D%2C%7B%22op%22%3A%22HEATMAP%22%2C%22column%22%3A%22duration_ms%22%7D%5D%2C%22filters%22%3A%5B%7B%22column%22%3A%22app.name%22%2C%22op%22%3A%22%3D%22%2C%22value%22%3A%22{{ .Config.Name }}%22%7D%5D%2C%22filter_combination%22%3A%22AND%22%2C%22orders%22%3A%5B%7B%22column%22%3A%22duration_ms%22%2C%22op%22%3A%22P95%22%2C%22order%22%3A%22descending%22%7D%5D%2C%22havings%22%3A%5B%5D%2C%22limit%22%3A1000%7D) 
+and add `deployment.namespace = {{ .Config.Name }}--<bento>` to the `WHERE` clause, where `<bento>` is the bento that
+this alert fired in. These traces may provide an idea as to what could be the root cause of the errors.
+
+<!--- Block(podMemorySpikeHoneycomb) -->
+{{ file.Block "podMemorySpikeHoneycomb" }}
+<!--- EndBlock(podMemorySpikeHoneycomb) -->
+
+## Resolution
+
+Once you determine what the errors are, they fall usually fall into one of several categories categories:
+
+1. Too many requests: If the number of requests drops, then the service should recover on it’s own.
+
+2. Hardware error: The solution is to restart the pod. The simplest way to due this is by triggering a new deployment with:
+
+`kubectl --context <context> -n {{ .Config.Name }}--<bento> patch deployment {{ .Config.Name }} -p "{\"spec\": {\"template\": {\"metadata\": { \"labels\": { \"redeploy\": \"$(date +%s)\"}}}}}"`
+
+Substitute the appropriate values for `<context>` and `<bento>` based on the environment and bento you want to modify. Refer to [Deployments](/documentation/deployments.md) for a mapping from bento to context.
+
+Verify the pods are cycling by executing:
+
+`kubectl --context <context> -n {{ .Config.Name }}--<bento> get pods`
+
+and verifying the pods are restarting, or recently restarted.
+
+<!--- Block(podMemorySpikeResolution) -->
+{{ file.Block "podMemorySpikeResolution" }}
+<!--- EndBlock(podMemorySpikeResolution) -->
 
 <!--- Block(podMemorySpike) -->
 {{ file.Block "podMemorySpike" }}

--- a/templates/documentation/runbooks/pod-restarts.md.tpl
+++ b/templates/documentation/runbooks/pod-restarts.md.tpl
@@ -1,6 +1,7 @@
 {{- if not (stencil.Arg "service") }}
 {{- file.Skip "project is not a service" }}
 {{- end }}
+{{- $dashboard := stencil.Arg "datadogDashboards.mainLink" }}
 <!-- Space: {{ stencil.Arg "opslevel.confluenceSpaceKey" }} -->
 <!-- Parent: Service Documentation 🧊 -->
 <!-- Parent: {{ .Config.Name }} 🧊 -->

--- a/templates/documentation/runbooks/pod-restarts.md.tpl
+++ b/templates/documentation/runbooks/pod-restarts.md.tpl
@@ -52,11 +52,12 @@ where `<pod name>` is the name of the pod that just recently started up after th
 
 ### Datadog Dashboard and Logs
 
-The {{ .Config.Name }} service has a dashboard in Datadog: https://app.datadoghq.com/dashboard/i6z-jcn-azh/terraform-{{ .Config.Name }}
+The {{ .Config.Name }} service has a [Datadog dashboard]({{ $dashboard }}). 
 
 Look for any anomalies in the dashboard.
 
-{{ camelcase .Config.Name }} logs are available via a search: https://app.datadoghq.com/logs/livetail?query=service%3A{{ .Config.Name }}%20environment%3Aproduction%20status%3Aerror&index=main&from_ts=1652033594145&to_ts=1652206394145&live=true. Modify the search parameters to match the bento and environment the alert was generated from.
+To look for signs of issues or abnormal behavior in the logs, [navigate to Datadog](https://app.datadoghq.com/logs?query=service%3A{{ .Config.Name }}%20status%3Aerror) and
+add the `@deployment.bento:<bento>` facet, where `<bento>` is the bento that this alert fired in.
 
 Look at the {{ camelcase .Config.Name }} logs for a log line like the following:
 
@@ -74,7 +75,7 @@ Modify the `<bento>` value to match the bento the issue is alerting from. Once y
 
 Often times the historical state and logs are not easily accessible from within the running cluster. If the logs from the crashed pod are not readily retrievable they may be archived in Komodor.
 
-Start by navigating to the {{ camelcase .Config.Name }} service list in Komodor: https://app.komodor.com/main/services?textFilter={{ .Config.Name }}&filters=%7B%7D&tabType=service
+Start by navigating to the {{ camelcase .Config.Name }} [service list in Komodor](https://app.komodor.com/main/services?textFilter={{ .Config.Name }}&filters=%7B%7D&tabType=service)
 
 From the main service list page select the bento that is alerting and view the pod status. You will likely want to inspect the pod details and logs:
 

--- a/templates/documentation/runbooks/pod-restarts.md.tpl
+++ b/templates/documentation/runbooks/pod-restarts.md.tpl
@@ -56,16 +56,16 @@ The {{ .Config.Name }} service has a [Datadog dashboard]({{ $dashboard }}).
 
 Look for any anomalies in the dashboard.
 
-To look for signs of issues or abnormal behavior in the logs, [navigate to Datadog](https://app.datadoghq.com/logs?query=service%3A{{ .Config.Name }}%20status%3Aerror) and
-add the `@deployment.bento:<bento>` facet, where `<bento>` is the bento that this alert fired in.
-
-Look at the {{ camelcase .Config.Name }} logs for a log line like the following:
+Look in the [logs](https://app.datadoghq.com/logs?query=service%3A{{ .Config.Name }}%20%22Pod%20Restarts%22) to see if the pod restarts generated error logs that looks similar to:
 
 ```
 [Triggered on {kube_namespace:{ .Config.Name }}--<bento>}] { .Config.Name }} Pod Restarts > 0 last 30m
 ```
 
-Modify the `<bento>` value to match the bento the issue is alerting from. Once you find that line, then look at the few minutes before that for logs that give any indication of unpredictable behavior from the service itself.
+Add the `@deployment.bento:<bento>` facet, where `<bento>` is the bento that this alert fired in. Use these logs to start correlating error and alert timing and identifying service activity around the time the pod restarts occurred. Once you find the pod restart logs look at the few minutes before that for logs that give any indication of the behavior from the service itself.
+
+To look for other signs of issues or abnormal behavior in the logs, [navigate to Datadog](https://app.datadoghq.com/logs?query=service%3A{{ .Config.Name }}%20status%3Aerror) and
+add the `@deployment.bento:<bento>` facet, where `<bento>` is the bento that this alert fired in.
 
 <!--- Block(podRestartsDatadog) -->
 {{ file.Block "podRestartsDatadog" }}
@@ -77,7 +77,7 @@ Often times the historical state and logs are not easily accessible from within 
 
 Start by navigating to the {{ camelcase .Config.Name }} [service list in Komodor](https://app.komodor.com/main/services?textFilter={{ .Config.Name }}&filters=%7B%7D&tabType=service)
 
-From the main service list page select the bento that is alerting and view the pod status. You will likely want to inspect the pod details and logs:
+From the main service list page select the bento that is alerting and view the pod status. If the list of bentos is long you can filter the bentos by namespace to shorten the list of bentos and make it easier to identify the relevant bento deployment. As a reminder, Kubernetes namespaces, by convention, are formatted like `{{ .Config.Name }}--<bento>`, where `<bento>` is the bento name.
 
 Once in the pod details page look for events or logs (both current and previous) that may provide clues to the root cause of the low number of running pods:
 

--- a/templates/documentation/runbooks/service-panics.md.tpl
+++ b/templates/documentation/runbooks/service-panics.md.tpl
@@ -1,6 +1,7 @@
 {{- if not (stencil.Arg "service") }}
 {{- file.Skip "project is not a service" }}
 {{- end }}
+{{- $dashboard := stencil.Arg "datadogDashboards.mainLink" }}
 <!-- Space: {{ stencil.Arg "opslevel.confluenceSpaceKey" }} -->
 <!-- Parent: Service Documentation 🧊 -->
 <!-- Parent: {{ .Config.Name }} 🧊 -->

--- a/templates/documentation/runbooks/service-panics.md.tpl
+++ b/templates/documentation/runbooks/service-panics.md.tpl
@@ -64,7 +64,7 @@ Often times the historical state and logs are not easily accessible from within 
 
 Start by navigating to the {{ camelcase .Config.Name }} [service list in Komodor](https://app.komodor.com/main/services?textFilter={{ .Config.Name }}&filters=%7B%7D&tabType=service)
 
-From the main service list page select the bento that is alerting and view the pod status. You will likely want to inspect the pod details and logs:
+From the main service list page select the bento that is alerting and view the pod status. If the list of bentos is long you can filter the bentos by namespace to shorten the list of bentos and make it easier to identify the relevant bento deployment. As a reminder, Kubernetes namespaces, by convention, are formatted like `{{ .Config.Name }}--<bento>`, where `<bento>` is the bento name.
 
 Once in the pod details page look for events or logs (both current and previous) that may provide clues to the root cause of the low number of running pods:
 

--- a/templates/documentation/runbooks/service-panics.md.tpl
+++ b/templates/documentation/runbooks/service-panics.md.tpl
@@ -9,9 +9,78 @@
 
 # {{ camelcase .Config.Name }} Service Panics
 
+## Investigation
+
+### Datadog Dashboard and Logs
+
+The {{ .Config.Name }} service has a dashboard in Datadog: https://app.datadoghq.com/dashboard/i6z-jcn-azh/terraform-{{ .Config.Name }}
+
+Look for any anomalies in the dashboard.
+
 [Navigate to Datadog](https://app.datadoghq.com/logs?query=service%3A{{ .Config.Name }}%20status%3Aerror) and
 add the `@deployment.bento:<bento>` facet, where `<bento>` is the bento that this alert fired in. These logs
 should provide an idea as to what could be the root cause of the panics.
+
+<!--- Block(servicePanicsDatadog) -->
+{{ file.Block "servicePanicsDatadog" }}
+<!--- EndBlock(servicePanicsDatadog) -->
+
+### Kubernetes Pod State
+
+List the pods in the bento that the alert fired in for this service:
+
+```shell
+kubectl -n {{ .Config.Name }}--<bento> get pods
+```
+
+It's likely that some number of service pods have a high number of restarts, describe them:
+
+```shell
+kubectl -n {{ .Config.Name }}--<bento> describe pod <pod name>
+```
+
+Look at the events and last known state when describing the pods, one of these areas should lead in the
+correct direction of the source of the problem. It may also be a useful exercise to peek at the deployment:
+
+```shell
+kubectl -n {{ .Config.Name }}--<bento> describe deployment {{ .Config.Name }}
+```
+
+If a pod recently crashed the previous logs may still be available and viewable via:
+
+```shell
+kubectl -n {{ .Config.Name }}--<bento> logs --previous <pod name>
+```
+
+where `<pod name>` is the name of the pod that just recently started up after the crash
+
+<!--- Block(servicePanicsPodState) -->
+{{ file.Block "servicePanicsPodState" }}
+<!--- EndBlock(servicePanicsPodState) -->
+
+### Check Komodor for Pod State and Logs
+
+Often times the historical state and logs are not easily accessible from within the running cluster. If the logs from the crashed pod are not readily retrievable they may be archived in Komodor.
+
+Start by navigating to the {{ camelcase .Config.Name }} service list in Komodor: https://app.komodor.com/main/services?textFilter={{ .Config.Name }}&filters=%7B%7D&tabType=service
+
+From the main service list page select the bento that is alerting and view the pod status. You will likely want to inspect the pod details and logs:
+
+Once in the pod details page look for events or logs (both current and previous) that may provide clues to the root cause of the low number of running pods:
+
+<!--- Block(servicePanicsKomodor) -->
+{{ file.Block "servicePanicsKomodor" }}
+<!--- EndBlock(servicePanicsKomodor) -->
+
+<!--- Block(servicePanicsInvestigation) -->
+{{ file.Block "servicePanicsInvestigation" }}
+<!--- EndBlock(servicePanicsInvestigation) -->
+
+# Resolution
+
+<!--- Block(servicePanicsResolution) -->
+{{ file.Block "servicePanicsResolution" }}
+<!--- EndBlock(servicePanicsResolution) -->
 
 <!--- Block(servicePanics) -->
 {{ file.Block "servicePanics" }}

--- a/templates/documentation/runbooks/service-panics.md.tpl
+++ b/templates/documentation/runbooks/service-panics.md.tpl
@@ -13,7 +13,7 @@
 
 ### Datadog Dashboard and Logs
 
-The {{ .Config.Name }} service has a dashboard in Datadog: https://app.datadoghq.com/dashboard/i6z-jcn-azh/terraform-{{ .Config.Name }}
+The {{ .Config.Name }} service has a [Datadog dashboard]({{ $dashboard }}). 
 
 Look for any anomalies in the dashboard.
 
@@ -62,7 +62,7 @@ where `<pod name>` is the name of the pod that just recently started up after th
 
 Often times the historical state and logs are not easily accessible from within the running cluster. If the logs from the crashed pod are not readily retrievable they may be archived in Komodor.
 
-Start by navigating to the {{ camelcase .Config.Name }} service list in Komodor: https://app.komodor.com/main/services?textFilter={{ .Config.Name }}&filters=%7B%7D&tabType=service
+Start by navigating to the {{ camelcase .Config.Name }} [service list in Komodor](https://app.komodor.com/main/services?textFilter={{ .Config.Name }}&filters=%7B%7D&tabType=service)
 
 From the main service list page select the bento that is alerting and view the pod status. You will likely want to inspect the pod details and logs:
 


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions:
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->

<!-- A short description of what your PR does and what it solves. -->

## What this PR does / why we need it

While updating the runbooks for the usermanager service to be compatible with bootstrap v10 in https://github.com/getoutreach/usermanager/pull/284 it was suggested that most of the details in the runbooks for usermanager was generally applicable to all services. The changes in this PR migrate the instructions from the usermanager runbooks to the common stencil-base runbook templates to make them more generally available for all services and improve the quality of the the runbooks for all.

I also left configurable blocks in all sections to allow teams to extend each section of the runbooks with service specific details as appropriate.

<!--- Block(jiraPrefix) --->

## Jira ID

[EG-487]

<!--- EndBlock(jiraPrefix) --->

<!-- Notes that may be helpful for anyone reviewing this PR -->

## Notes for your reviewers

<!--- Block(custom) -->

<!--- EndBlock(custom) -->


[EG-487]: https://outreach-io.atlassian.net/browse/EG-487?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ