### PR TITLE
fix: allow services/libs to add extra badges

### DIFF
--- a/templates/README.md.tpl
+++ b/templates/README.md.tpl
@@ -12,6 +12,9 @@
 {{- end }}
 [![Generated via Bootstrap](https://img.shields.io/badge/Outreach-Bootstrap-%235951ff)](https://github.com/getoutreach/bootstrap)
 [![Coverage Status](https://coveralls.io/repos/github/{{ .Runtime.Box.Org }}/{{ .Config.Name }}/badge.svg?branch={{ .Git.DefaultBranch }})](https://coveralls.io/github//{{ .Runtime.Box.Org }}/{{ .Config.Name }}?branch={{ .Git.DefaultBranch }})
+<!--- Block(extraBadges) -->
+{{ file.Block "extraBadges" }}
+<!--- EndBlock(extraBadges) -->
 
 {{ stencil.Arg "description" }}
 


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions:
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->

<!-- A short description of what your PR does and what it solves. -->

## What this PR does / why we need it
In clerkschema we want to have an argoCD badge for our (own) prod deployment right on the README.

<!--- Block(jiraPrefix) --->

## Jira ID

[CDT-00]

<!--- EndBlock(jiraPrefix) --->

<!-- Notes that may be helpful for anyone reviewing this PR -->

## Notes for your reviewers

<!--- Block(custom) -->

<!--- EndBlock(custom) -->
