### PR TITLE
fix: put ASDF tool ver overrides above default provisioned

### DIFF
--- a/templates/.tool-versions.tpl
+++ b/templates/.tool-versions.tpl
@@ -1,12 +1,12 @@
 # This file contains tool versions for use with asdf
-{{- range stencil.GetModuleHook "toolVersions" }}
-{{ printf "%s %s" .name (toString .version) }}
-{{- end }}
-# Note: Versions in this block override the above. Be EXTREMELY
-# CAREFUL with this. If you override a standard version you are
-# reducing compatibility guarantees.
+# Note: Versions in this block override the default versions below.
+# Be EXTREMELY CAREFUL with this. If you override a standard version
+# you are reducing compatibility guarantees.
 ###Block(toolver)
 {{- if file.Block "toolver" }}
 {{ file.Block "toolver" }}
 {{- end }}
 ###EndBlock(toolver)
+{{- range stencil.GetModuleHook "toolVersions" }}
+{{ printf "%s %s" .name (toString .version) }}
+{{- end }}


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions:
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->

<!-- A short description of what your PR does and what it solves. -->

## What this PR does / why we need it
If tool-versions have the same tool listed twice, ASDF picks the first (not the last). This renders the override block ineffective because defaults always force ASDF to pick them. This is causing troubles to services repo - this repo needs older protoc version due to a bug in the latest protoc releases (https://github.com/protocolbuffers/protobuf-javascript/issues/127) but the clerk team pushes to latest one now, breaking the services repo.

The only two repos impacted are services and authz. I will manually test and update both of the repos to prepare them for V11 bootstrap after this PR merges. Other repos that provide tools in the tool versions override only add new ones - those won't be impacted.

<!--- Block(jiraPrefix) --->

## Jira ID

[DT-2839]

<!--- EndBlock(jiraPrefix) --->

<!-- Notes that may be helpful for anyone reviewing this PR -->

## Notes for your reviewers

<!--- Block(custom) -->

<!--- EndBlock(custom) -->


[DT-2839]: https://outreach-io.atlassian.net/browse/DT-2839?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ