### PR TITLE
chore: add .dir-locals.el to .gitignore

### DIFF
--- a/templates/.gitignore.tpl
+++ b/templates/.gitignore.tpl
@@ -14,6 +14,7 @@ TAGS
 *.sublime-project
 *.sublime-workspace
 .\#*
+.dir-locals.el
 
 # Test binary, build with "go test -c"
 *.test


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it
Adds `.dir-locals.el` to the `.gitignore` template's editor section to ignore local project variables set for Emacs.


<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[XX-XX]

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers



<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->
