### PR TITLE
fix: drop go 1.16 support in go mod tidy

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -7,11 +7,11 @@ postRunCommand:
   - name: asdf install
     command: ./scripts/devbase.sh; source .bootstrap/shell/lib/asdf.sh; asdf_install
   - name: go mod tidy
-    command: go mod tidy -go=1.16 && go mod tidy -go=1.17
+    command: go mod tidy -compat=1.17
   - name: Format Files
     command: make gogenerate fmt
   - name: go mod tidy
-    command: go mod tidy -go=1.16 && go mod tidy -go=1.17
+    command: go mod tidy -compat=1.17
 arguments:
   releaseOptions.enablePrereleases:
     description: Enable prereleases


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it

This drops support for 1.16 versions of modules. We still have the same issue with plain `go mod tidy` producing the below error message, but this lets us grab newer versions of packages.

Error message sample:

```
github.com/getoutreach/devbase/v2/root imports
        github.com/opslevel/opslevel-go/v2022 imports
        golang.org/x/oauth2 loaded from golang.org/x/oauth2@v0.0.0-20220608161450-d0670ef3b1eb,
        but go 1.16 would select v0.0.0-20220622183110-fd043fe589d2
github.com/getoutreach/devbase/v2/root imports
        github.com/opslevel/opslevel-go/v2022 imports
        golang.org/x/oauth2 imports
        golang.org/x/oauth2/internal loaded from golang.org/x/oauth2@v0.0.0-20220608161450-d0670ef3b1eb,
        but go 1.16 would select v0.0.0-20220622183110-fd043fe589d2

To upgrade to the versions selected by go 1.16:
        go mod tidy -go=1.16 && go mod tidy -go=1.17
If reproducibility with go 1.16 is not needed:
        go mod tidy -compat=1.17
For other options, see:
        https://golang.org/doc/modules/pruning
```

<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[XX-XX]

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers



<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->
