### PR TITLE
fix: set manifest.yaml devbase version to rc

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -2,7 +2,7 @@ name: github.com/getoutreach/stencil-base
 ## <<Stencil::Block(keys)>>
 modules:
   - name: github.com/getoutreach/devbase
-    version: ">=v2.7.0"
+    version: ">=v2.9.0-rc.12"
 postRunCommand:
   - name: asdf install
     command: ./scripts/devbase.sh; source .bootstrap/shell/lib/asdf.sh; asdf_install


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it
Fixes a conflict between stencil-base and stencil-circleci providing conflicting versions. 
Will also update a PR to fix this here: https://github.com/getoutreach/stencil-circleci/blob/b3ea44dd28034ed2283b32132e0459dd1dcaa023/manifest.yaml#L5


<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[DT-3489]

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers



<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->


[DT-3489]: https://outreach-io.atlassian.net/browse/DT-3489?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ