### PR TITLE
fix(postRun): run fmt before gogenerate

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -8,8 +8,12 @@ postRunCommand:
     command: ./scripts/devbase.sh; source .bootstrap/shell/lib/asdf.sh; asdf_install
   - name: go mod tidy
     command: go mod tidy -compat=1.17
-  - name: Format Files
-    command: make gogenerate fmt
+  - name: Format Files (step 1)
+    command: make fmt
+  - name: Generate Files
+    command: make gogenerate
+  - name: Format Files (step 2)
+    command: make fmt
   - name: go mod tidy
     command: go mod tidy -compat=1.17
 arguments:


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it

Some generators require code to be formatted / compilable before they can be run, so try `make fmt` before and then after. Also, separate the steps to make it more clear which one failed.

This isn't a good long-term solution, to be clear, but it's the best quick hack I can think of.
