### PR TITLE
fix: add hook to allow add more gitignore from other modules

### DIFF
--- a/templates/.gitignore.tpl
+++ b/templates/.gitignore.tpl
@@ -61,6 +61,13 @@ Pulumi.*.yaml
 # Documentation output
 /apidocs
 
+### Start ignores inserted by other modules
+{{- $extraHook := (stencil.GetModuleHook "extraIgnores") }}
+{{- range $extraHook }}
+{{- .}}
+{{- end }}
+### End ignores inserted by other modules
+
 ## <<Stencil::Block(extras)>>
 {{ file.Block "extras" }}
 ## <</Stencil::Block>>

--- a/templates/.gitignore.tpl
+++ b/templates/.gitignore.tpl
@@ -62,7 +62,7 @@ Pulumi.*.yaml
 /apidocs
 
 ### Start ignores inserted by other modules
-{{- $extraHook := (stencil.GetModuleHook "extraIgnores") }}
+{{- $extraHook := (stencil.GetModuleHook "gitIgnore/extraIgnores") }}
 {{- range $extraHook }}
 {{- .}}
 {{- end }}


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it

add hook to allow add more gitignore from other modules

<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[[DSC-10572](https://outreach-io.atlassian.net/browse/DSC-10572)]

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers

Tested the usage from local runs. Usages example is [here](https://github.com/getoutreach/stencil-ds-python-service/pull/1/files#diff-b525da928b7e87c7ecb0453434bfc81795e0c07f96fdfc5e220fd1a7b2621f39)

<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->


[DSC-10572]: https://outreach-io.atlassian.net/browse/DSC-10572?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ