### PR TITLE
fix(manifest): remove rc import, remove duplicated schema for serviceActivies

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -1,8 +1,5 @@
 name: github.com/getoutreach/stencil-base
 ## <<Stencil::Block(keys)>>
-modules:
-  - name: github.com/getoutreach/devbase
-    version: ">=v2.9.0-rc.12"
 postRunCommand:
   - name: asdf install
     command: ./scripts/devbase.sh; source .bootstrap/shell/lib/asdf.sh; asdf_install
@@ -47,12 +44,10 @@ arguments:
       type: array
       items:
         type: string
-        enum:
-          - http
-          - grpc
-          - temporal
-          - kafka
-    description: Any valid built-in service activities can be supplied here and they will be provided. The `service` flag must be set to true. Valid values for this are `http`, `grpc`, `temporal`, and `kafka`.
+    description: |-
+      Any valid built-in service activities can be supplied here and they will be provided. 
+      The `service` flag must be set to true. See 'stencil-golang' for valid values, this will eventually be removed
+      from `stencil-base` as it's not meant to be used here.
   reportingTeam:
     required: true
     schema:


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it

Removes an `rc` import that was left over during the last release. Also removes the schema for `serviceActivities` since it's duplicative and not the authority on valid values. Instead `stencil-golang` should error/validate the values.

<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[XX-XX]

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers



<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->
