### PR TITLE
fix(manifest): depend on stencil-base

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -1,5 +1,7 @@
 name: github.com/getoutreach/stencil-base
 ## <<Stencil::Block(keys)>>
+modules:
+  - name: github.com/getoutreach/devbase
 postRunCommand:
   - name: asdf install
     command: ./scripts/devbase.sh; source .bootstrap/shell/lib/asdf.sh; asdf_install


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it

This PR fixes stencil-base to depend on `devbase`, because it does with it's post run commands :D 

<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[XX-XX]

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers



<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->
