### PR TITLE
feat: Moving README and CONTRIBUTING files to be Static

### DIFF
--- a/templates/CONTRIBUTING.md.tpl
+++ b/templates/CONTRIBUTING.md.tpl
@@ -1,8 +1,5 @@
+{{- $_ := file.Static -}}
 # {{ .Config.Name }}
-
-<!-- <<Stencil::Block(customGeneralInformation)>> -->
-{{ file.Block "customGeneralInformation" }}
-<!-- <</Stencil::Block>> -->
 
 ## Prerequisites
 
@@ -10,17 +7,9 @@
 Make sure you've ran `orc setup`.
 {{- end }}
 
-<!-- <<Stencil::Block(customPrerequisites)>> -->
-{{ file.Block "customPrerequisites" }}
-<!-- <</Stencil::Block>> -->
-
 ## Building and Testing
 
 This project uses devbase, which exposes the following build tooling: [devbase/docs/makefile.md](https://github.com/getoutreach/devbase/blob/main/docs/makefile.md)
-
-<!-- <<Stencil::Block(customBuildingAndTesting)>> -->
-{{ file.Block "customBuildingAndTesting" }}
-<!-- <</Stencil::Block>> -->
 
 {{- if (stencil.Arg "service") }}
 ### Building and Running

--- a/templates/README.md.tpl
+++ b/templates/README.md.tpl
@@ -1,3 +1,4 @@
+{{- $_ := file.Static -}}
 # {{ .Config.Name }}
 
 {{- if (stencil.Arg "oss") }}
@@ -12,9 +13,6 @@
 {{- end }}
 [![Generated via Bootstrap](https://img.shields.io/badge/Outreach-Bootstrap-%235951ff)](https://github.com/getoutreach/bootstrap)
 [![Coverage Status](https://coveralls.io/repos/github/{{ .Runtime.Box.Org }}/{{ .Config.Name }}/badge.svg?branch={{ .Git.DefaultBranch }})](https://coveralls.io/github//{{ .Runtime.Box.Org }}/{{ .Config.Name }}?branch={{ .Git.DefaultBranch }})
-<!-- <<Stencil::Block(extraBadges)>> -->
-{{ file.Block "extraBadges" }}
-<!-- <</Stencil::Block>> -->
 
 {{ stencil.Arg "description" }}
 
@@ -24,9 +22,7 @@ Please read the [CONTRIBUTING.md](CONTRIBUTING.md) document for guidelines on de
 
 ## High-level Overview
 
-<!-- <<Stencil::Block(overview)>> -->
-{{ file.Block "overview" }}
-<!-- <</Stencil::Block>> -->
+[TODO]
 
 {{- if (stencil.Arg "service") }}
 ## Dependencies


### PR DESCRIPTION
These doc files have been very inflexible for teams to write useful documentation on top of, and hence the vast majority of services have exactly this doc available out of the box with no changes.  This change will allow teams to do whatever they desire with the README docs.
