### PR TITLE
fix: Link to a non-Outreach definition of conventional commits.

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,7 +1,7 @@
 <!--
   !!!! README !!!! Please fill this out.
 
-  Please follow the PR naming conventions: 
+  Please follow the PR naming conventions:
   https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
 -->
 

--- a/templates/.github/pull_request_template.md.tpl
+++ b/templates/.github/pull_request_template.md.tpl
@@ -1,8 +1,9 @@
 <!--
   !!!! README !!!! Please fill this out.
 
-  Please follow the PR naming conventions: 
-  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
+  Please follow conventional commit naming conventions:
+
+  https://www.conventionalcommits.org/en/v1.0.0/#summary
 -->
 
 

--- a/templates/.snapshots/TestRenderPullRequestTemplateFile-.github-pull_request_template.md.tpl-.github-pull_request_template.md.snapshot
+++ b/templates/.snapshots/TestRenderPullRequestTemplateFile-.github-pull_request_template.md.tpl-.github-pull_request_template.md.snapshot
@@ -1,8 +1,9 @@
 (*codegen.File)(<!--
   !!!! README !!!! Please fill this out.
 
-  Please follow the PR naming conventions: 
-  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
+  Please follow conventional commit naming conventions:
+
+  https://www.conventionalcommits.org/en/v1.0.0/#summary
 -->
 
 Please read [CONTRIBUTING.md](CONTRIBUTING.md) for additional information on contributing to this repository!


### PR DESCRIPTION
This is a more useful document _and _ works for open-source projects.