### PR TITLE
fix: use box to populate org name

### DIFF
--- a/templates/.snapshots/TestRenderReadmeFile-README.md.tpl-README.md.snapshot
+++ b/templates/.snapshots/TestRenderReadmeFile-README.md.tpl-README.md.snapshot
@@ -1,0 +1,15 @@
+(*codegen.File)(# testing
+[![go.dev reference](https://img.shields.io/badge/go.dev-reference-007d9c?logo=go&logoColor=white)](https://engdocs.outreach.cloud/github.com/getoutreach/testing)
+[![Generated via Bootstrap](https://img.shields.io/badge/Outreach-Bootstrap-%235951ff)](https://github.com/getoutreach/bootstrap)
+[![Coverage Status](https://coveralls.io/repos/github/getoutreach/testing/badge.svg?branch=)](https://coveralls.io/github//getoutreach/testing?branch=)
+
+My service
+
+## Contributing
+
+Please read the [CONTRIBUTING.md](CONTRIBUTING.md) document for guidelines on developing and contributing changes.
+
+## High-level Overview
+
+[TODO]
+)

--- a/templates/CONTRIBUTING.md.tpl
+++ b/templates/CONTRIBUTING.md.tpl
@@ -15,7 +15,7 @@ This project uses devbase, which exposes the following build tooling: [devbase/d
 ### Building and Running
 
 If you want to add this to your developer environment, please check out the section in the
-README.md about [adding to this developer environment](https://github.com/getoutreach/{{ .Config.Name }}#add-to-your-development-environment).
+README.md about [adding to this developer environment](https://github.com/{{ .Runtime.Box.Org }}/{{ .Config.Name }}#add-to-your-development-environment).
 
 If you want to run this locally, you can do the following:
 
@@ -52,7 +52,7 @@ If you want to test a package exposed in this repository in a project that uses 
 add the following `replace` directive to that project's `go.mod` file:
 
 ```
-replace github.com/getoutreach/{{ .Config.Name }} => /path/to/local/version/{{ .Config.Name }}
+replace github.com/{{ .Runtime.Box.Org }}/{{ .Config.Name }} => /path/to/local/version/{{ .Config.Name }}
 ```
 
 **_Note_**: This repository may have postfixed it's module path with a version, go check the first

--- a/templates/README.md.tpl
+++ b/templates/README.md.tpl
@@ -2,13 +2,13 @@
 # {{ .Config.Name }}
 
 {{- if (stencil.Arg "oss") }}
-[![go.dev reference](https://img.shields.io/badge/go.dev-reference-007d9c?logo=go&logoColor=white)](https://pkg.go.dev/github.com/getoutreach/{{ .Config.Name }})
+[![go.dev reference](https://img.shields.io/badge/go.dev-reference-007d9c?logo=go&logoColor=white)](https://pkg.go.dev/github.com/{{ .Runtime.Box.Org }}/{{ .Config.Name }})
 {{- else }}
-[![go.dev reference](https://img.shields.io/badge/go.dev-reference-007d9c?logo=go&logoColor=white)](https://engdocs.outreach.cloud/github.com/getoutreach/{{ .Config.Name }})
+[![go.dev reference](https://img.shields.io/badge/go.dev-reference-007d9c?logo=go&logoColor=white)](https://engdocs.outreach.cloud/github.com/{{ .Runtime.Box.Org }}/{{ .Config.Name }})
 {{- end }}
 {{- if ne nil (stencil.Arg "circleAPIKey") }}
 {{- if ne "" (stencil.Arg "circleAPIKey") }}
-[![CircleCI](https://circleci.com/gh/getoutreach/{{ .Config.Name }}.svg?style=shield&circle-token={{ stencil.Arg "circleAPIKey" }})](https://circleci.com/gh/getoutreach/{{ .Config.Name }})
+[![CircleCI](https://circleci.com/gh/{{ .Runtime.Box.Org }}/{{ .Config.Name }}.svg?style=shield&circle-token={{ stencil.Arg "circleAPIKey" }})](https://circleci.com/gh/{{ .Runtime.Box.Org }}/{{ .Config.Name }})
 {{- end }}
 {{- end }}
 [![Generated via Bootstrap](https://img.shields.io/badge/Outreach-Bootstrap-%235951ff)](https://github.com/getoutreach/bootstrap)

--- a/templates/main_test.go
+++ b/templates/main_test.go
@@ -13,6 +13,14 @@ func TestRenderAFile(t *testing.T) {
 	st.Run(false)
 }
 
+func TestRenderReadmeFile(t *testing.T) {
+	st := stenciltest.New(t, "README.md.tpl", "_helpers.tpl")
+	st.Args(map[string]interface{}{
+		"description": "My service",
+	})
+	st.Run(false)
+}
+
 func TestRenderPullRequestTemplateFile(t *testing.T) {
 	st := stenciltest.New(t, ".github/pull_request_template.md.tpl", "_helpers.tpl")
 	st.Args(map[string]interface{}{})


### PR DESCRIPTION
## What this PR does / why we need it

Removed instances where the GitHub org name was hardcoded, which makes it difficult to use outside of Outreach.