### PR TITLE
feat: add additionalRepoOwners to specify repo co-owners

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -47,7 +47,7 @@ arguments:
       items:
         type: string
     description: |-
-      Any valid built-in service activities can be supplied here and they will be provided. 
+      Any valid built-in service activities can be supplied here and they will be provided.
       The `service` flag must be set to true. See 'stencil-golang' for valid values, this will eventually be removed
       from `stencil-base` as it's not meant to be used here.
   reportingTeam:
@@ -55,6 +55,12 @@ arguments:
     schema:
       type: string
     description: Github team to be used as the CODEOWNER of this repository.
+  additionalRepoOwners:
+    schema:
+      type: array
+      items:
+        type: string
+    description: A list of GitHub teams who co-own the repository.
   dependencies.optional:
     schema:
       type: array

--- a/templates/.github/CODEOWNERS.tpl
+++ b/templates/.github/CODEOWNERS.tpl
@@ -1,5 +1,6 @@
 # See https://help.github.com/articles/about-codeowners/
-* @getoutreach/{{ stencil.Arg "reportingTeam" }}
+{{- $orgName := .Runtime.Box.Org }}
+* @{{ $orgName }}/{{ stencil.Arg "reportingTeam" }}{{ range stencil.Arg "additionalRepoOwners" }} @{{ $orgName }}/{{ . }}{{ end }}
 
 ## <<Stencil::Block(customCodeowners)>>
 {{ file.Block "customCodeowners" }}

--- a/templates/.snapshots/TestRenderCodeownersFile-.github-CODEOWNERS.tpl-.github-CODEOWNERS.snapshot
+++ b/templates/.snapshots/TestRenderCodeownersFile-.github-CODEOWNERS.tpl-.github-CODEOWNERS.snapshot
@@ -1,0 +1,7 @@
+(*codegen.File)(# See https://help.github.com/articles/about-codeowners/
+* @getoutreach/foo-bar
+
+## <<Stencil::Block(customCodeowners)>>
+
+## <</Stencil::Block>>
+)

--- a/templates/.snapshots/TestRenderCodeownersWithExtraOwnersFile-.github-CODEOWNERS.tpl-.github-CODEOWNERS.snapshot
+++ b/templates/.snapshots/TestRenderCodeownersWithExtraOwnersFile-.github-CODEOWNERS.tpl-.github-CODEOWNERS.snapshot
@@ -1,0 +1,7 @@
+(*codegen.File)(# See https://help.github.com/articles/about-codeowners/
+* @getoutreach/foo-bar @getoutreach/bar-baz @getoutreach/baz-quux
+
+## <<Stencil::Block(customCodeowners)>>
+
+## <</Stencil::Block>>
+)

--- a/templates/main_test.go
+++ b/templates/main_test.go
@@ -26,3 +26,23 @@ func TestRenderPullRequestTemplateFile(t *testing.T) {
 	st.Args(map[string]interface{}{})
 	st.Run(false)
 }
+
+func TestRenderCodeownersFile(t *testing.T) {
+	st := stenciltest.New(t, ".github/CODEOWNERS.tpl", "_helpers.tpl")
+	st.Args(map[string]interface{}{
+		"reportingTeam": "foo-bar",
+	})
+	st.Run(false)
+}
+
+func TestRenderCodeownersWithExtraOwnersFile(t *testing.T) {
+	st := stenciltest.New(t, ".github/CODEOWNERS.tpl", "_helpers.tpl")
+	st.Args(map[string]interface{}{
+		"reportingTeam": "foo-bar",
+		"additionalRepoOwners": []interface{}{
+			"bar-baz",
+			"baz-quux",
+		},
+	})
+	st.Run(false)
+}


### PR DESCRIPTION
## What this PR does / why we need it

Does what it says on the tin, with some snapshot tests.

Also removes some trailing whitespace.

## Jira ID

[DT-4130]

[DT-4130]: https://outreach-io.atlassian.net/browse/DT-4130?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ