### PR TITLE
fix(semantic-release): allow libraries to release gRPC packages

### DIFF
--- a/templates/.releaserc.yaml.tpl
+++ b/templates/.releaserc.yaml.tpl
@@ -38,7 +38,7 @@ plugins:
   # This creates fancy release notes in our Github release
   - "@semantic-release/release-notes-generator"
 
-{{- if has "grpc" (stencil.Arg "serviceActivities") }}
+{{- if or (not (stencil.Arg "service")) (has "grpc" (stencil.Arg "serviceActivities")) }}
   {{- if has "node" (stencil.Arg "grpcClients") }}
   # Bump npm package.json version, and release to npm/github packages.
   # See devbase for the Github Packages part.

--- a/templates/.snapshots/TestReleaseRCForLibrary-.releaserc.yaml.tpl-.releaserc.yaml.snapshot
+++ b/templates/.snapshots/TestReleaseRCForLibrary-.releaserc.yaml.tpl-.releaserc.yaml.snapshot
@@ -1,0 +1,39 @@
+(*codegen.File)(
+preset: conventionalcommits
+branches:
+  - name: 
+plugins:
+  - - "@semantic-release/commit-analyzer"
+    - releaseRules:
+      - type: revert
+        release: patch
+      - type: perf
+        release: patch
+  # Block major version upgrades due to us not supporting them that well. This can
+  # be disabled by setting releaseOptions.allowMajorVersions, but be warned this
+  # is not well supported for services.
+  - - "@semantic-release/exec"
+    # We use generateNotesCmd instead of verifyConditionsCmd because it has access
+    # to last/nextRelease due to when the step runs.
+    - generateNotesCmd: |-
+        ./scripts/shell-wrapper.sh major-release-checker.js ${lastRelease.version} ${nextRelease.version}
+
+  # This creates fancy release notes in our Github release
+  - "@semantic-release/release-notes-generator"
+  # Release ruby packages
+  - - "@semantic-release/exec"
+    # We use generateNotesCmd because prepareCmd is not ran on dry-run
+    - generateNotesCmd: |-
+        ./scripts/shell-wrapper.sh ruby/build.sh ${nextRelease.version} 1>&2
+      publishCmd: |-
+        DRYRUN=${options.dryrun} ./scripts/shell-wrapper.sh ruby/publish.sh ${nextRelease.version}
+  # Store the package.json updates in Git
+  - - "@semantic-release/git"
+    - assets:
+        - api/clients/ruby/lib/testing_client/version.rb
+  - "@semantic-release/github"
+
+  ## <<Stencil::Block(customReleasePlugins)>>
+
+  ## <</Stencil::Block>>
+)

--- a/templates/.snapshots/TestReleaseRCWithNodeJSGRPCClient-.releaserc.yaml.tpl-.releaserc.yaml.snapshot
+++ b/templates/.snapshots/TestReleaseRCWithNodeJSGRPCClient-.releaserc.yaml.tpl-.releaserc.yaml.snapshot
@@ -1,0 +1,36 @@
+(*codegen.File)(
+preset: conventionalcommits
+branches:
+  - name: 
+plugins:
+  - - "@semantic-release/commit-analyzer"
+    - releaseRules:
+      - type: revert
+        release: patch
+      - type: perf
+        release: patch
+  # Block major version upgrades due to us not supporting them that well. This can
+  # be disabled by setting releaseOptions.allowMajorVersions, but be warned this
+  # is not well supported for services.
+  - - "@semantic-release/exec"
+    # We use generateNotesCmd instead of verifyConditionsCmd because it has access
+    # to last/nextRelease due to when the step runs.
+    - generateNotesCmd: |-
+        ./scripts/shell-wrapper.sh major-release-checker.js ${lastRelease.version} ${nextRelease.version}
+
+  # This creates fancy release notes in our Github release
+  - "@semantic-release/release-notes-generator"
+  # Bump npm package.json version, and release to npm/github packages.
+  # See devbase for the Github Packages part.
+  - - "@semantic-release/npm"
+    - pkgRoot: api/clients/node
+  # Store the package.json updates in Git
+  - - "@semantic-release/git"
+    - assets:
+        - api/clients/node/package.json
+  - "@semantic-release/github"
+
+  ## <<Stencil::Block(customReleasePlugins)>>
+
+  ## <</Stencil::Block>>
+)

--- a/templates/.snapshots/TestReleaseRCWithRubyGRPCClient-.releaserc.yaml.tpl-.releaserc.yaml.snapshot
+++ b/templates/.snapshots/TestReleaseRCWithRubyGRPCClient-.releaserc.yaml.tpl-.releaserc.yaml.snapshot
@@ -1,0 +1,39 @@
+(*codegen.File)(
+preset: conventionalcommits
+branches:
+  - name: 
+plugins:
+  - - "@semantic-release/commit-analyzer"
+    - releaseRules:
+      - type: revert
+        release: patch
+      - type: perf
+        release: patch
+  # Block major version upgrades due to us not supporting them that well. This can
+  # be disabled by setting releaseOptions.allowMajorVersions, but be warned this
+  # is not well supported for services.
+  - - "@semantic-release/exec"
+    # We use generateNotesCmd instead of verifyConditionsCmd because it has access
+    # to last/nextRelease due to when the step runs.
+    - generateNotesCmd: |-
+        ./scripts/shell-wrapper.sh major-release-checker.js ${lastRelease.version} ${nextRelease.version}
+
+  # This creates fancy release notes in our Github release
+  - "@semantic-release/release-notes-generator"
+  # Release ruby packages
+  - - "@semantic-release/exec"
+    # We use generateNotesCmd because prepareCmd is not ran on dry-run
+    - generateNotesCmd: |-
+        ./scripts/shell-wrapper.sh ruby/build.sh ${nextRelease.version} 1>&2
+      publishCmd: |-
+        DRYRUN=${options.dryrun} ./scripts/shell-wrapper.sh ruby/publish.sh ${nextRelease.version}
+  # Store the package.json updates in Git
+  - - "@semantic-release/git"
+    - assets:
+        - api/clients/ruby/lib/testing_client/version.rb
+  - "@semantic-release/github"
+
+  ## <<Stencil::Block(customReleasePlugins)>>
+
+  ## <</Stencil::Block>>
+)

--- a/templates/main_test.go
+++ b/templates/main_test.go
@@ -13,6 +13,45 @@ func TestRenderAFile(t *testing.T) {
 	st.Run(stenciltest.RegenerateSnapshots())
 }
 
+func TestReleaseRCWithNodeJSGRPCClient(t *testing.T) {
+	st := stenciltest.New(t, ".releaserc.yaml.tpl", "_helpers.tpl")
+	st.Args(map[string]interface{}{
+		"service": true,
+		"serviceActivities": []interface{}{
+			"grpc",
+		},
+		"grpcClients": []interface{}{
+			"node",
+		},
+	})
+	st.Run(stenciltest.RegenerateSnapshots())
+}
+
+func TestReleaseRCWithRubyGRPCClient(t *testing.T) {
+	st := stenciltest.New(t, ".releaserc.yaml.tpl", "_helpers.tpl")
+	st.Args(map[string]interface{}{
+		"service": true,
+		"serviceActivities": []interface{}{
+			"grpc",
+		},
+		"grpcClients": []interface{}{
+			"ruby",
+		},
+	})
+	st.Run(stenciltest.RegenerateSnapshots())
+}
+
+func TestReleaseRCForLibrary(t *testing.T) {
+	st := stenciltest.New(t, ".releaserc.yaml.tpl", "_helpers.tpl")
+	st.Args(map[string]interface{}{
+		"service": false,
+		"grpcClients": []interface{}{
+			"ruby",
+		},
+	})
+	st.Run(stenciltest.RegenerateSnapshots())
+}
+
 func TestRenderReadmeFile(t *testing.T) {
 	st := stenciltest.New(t, "README.md.tpl", "_helpers.tpl")
 	st.Args(map[string]interface{}{


### PR DESCRIPTION
## What this PR does / why we need it

Does what it says on the tin. Also adds snapshots for various gRPC client permutations.

## Jira ID

[DT-4300]

[DT-4300]: https://outreach-io.atlassian.net/browse/DT-4300?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ