### PR TITLE
fix: yarn install before upgrade

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -15,6 +15,8 @@ postRunCommand:
     command: make fmt
   - name: go mod tidy
     command: go mod tidy -compat=1.17
+  - name: yarn install
+    command: yarn install
   - name: yarn upgrade
     command: yarn upgrade
 arguments:


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow conventional commit naming conventions:

  https://www.conventionalcommits.org/en/v1.0.0/#summary
-->

Please read [CONTRIBUTING.md](CONTRIBUTING.md) for additional information on contributing to this repository!

<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it
`yarn upgrade` will fail if new modules were added to the project yet never installed. Its addition broke our e2e test which runs stencil in an isolated environment (it starts a fresh folder with `service.yaml` only and runs stencil on it):
* stencil generates first modules
* everything completes normally, but then `yarn upgrade` fails with
```
time="2024-07-10T18:28:18Z" level=info msg=" - yarn upgrade"
yarn upgrade v1.22.22
error No lockfile in this directory. Run `yarn install` to generate one.
info Visit https://yarnpkg.com/en/docs/cli/upgrade for documentation about this command.
time="2024-07-10T18:28:18Z" level=error msg="failed to run: run codegen: failed to run post run command for module \"github.com/getoutreach/stencil-base\": exit status 1"

```

Fix: exec the `yarn install` to install any freshly modules before upgrading them.

<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[XX-XX]

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers

<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->
