### PR TITLE
fix: post-run yarn if yarn.lock does not exist

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -15,8 +15,8 @@ postRunCommand:
     command: make fmt
   - name: go mod tidy
     command: go mod tidy -compat=1.17
-  - name: yarn upgrade
-    command: yarn upgrade
+  - name: Install or upgrade release-related Node.js packages
+    command: if test -f yarn.lock; then yarn upgrade; else yarn; fi
 arguments:
   releaseOptions.enablePrereleases:
     description: Enable prereleases


### PR DESCRIPTION
## What this PR does / why we need it

Replacement fix for #169. I tested this with an existing service by adding a local replacement directive in `service.yaml` and running the below steps.

## Jira ID

[DT-4444]

## Notes for your reviewers

Repro steps:

1. Clone any stenciled repo
2. Run `rm yarn.lock`
3. Run `stencil`

Expected: Works, `yarn.lock` recreated with possibly new changes

Actual: `yarn upgrade` fails, which causes `stencil` to fail

Closes #169.

[DT-4444]: https://outreach-io.atlassian.net/browse/DT-4444?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ