### PR TITLE
fix: remove obsolete hjson Node.js dependency

### DIFF
--- a/templates/package.json.tpl
+++ b/templates/package.json.tpl
@@ -8,9 +8,6 @@
     "@semantic-release/npm": "^12.0.0",
     "@semantic-release/release-notes-generator": "^13.0.0",
     "conventional-changelog-conventionalcommits": "^7.0.2",
-{{- if has "node" (stencil.Arg "grpcClients") }}
-    "hjson": "^3.2.2",
-{{- end }}
 {{- range stencil.GetModuleHook "nodejs_dependencies" }}
     "{{ .name }}": "{{ .version }}",
 {{- end }}


### PR DESCRIPTION
## What this PR does / why we need it

Companion PR to https://github.com/getoutreach/devbase/pull/936 (context available there)