### PR TITLE
feat: create templated mise config, move prettier to it

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -3,6 +3,8 @@ name: github.com/getoutreach/stencil-base
 modules:
   - name: github.com/getoutreach/devbase
 postRunCommand:
+  - name: Install tools from mise
+    command: mise install --yes
   - name: asdf install
     command: ./scripts/devbase.sh; source .bootstrap/shell/lib/asdf.sh; asdf_devbase_ensure
   - name: go mod tidy

--- a/templates/mise.toml.tpl
+++ b/templates/mise.toml.tpl
@@ -1,0 +1,32 @@
+[task_config]
+includes = [".bootstrap/.mise/tasks"]
+
+{{ $miseEnvironments := stencil.GetModuleHook "miseEnvironment" }}
+
+{{- if gt ($miseEnvironments | len) 0 }}
+[env]
+{{- range $miseEnvironments }}
+{{ . | toTOML }}
+{{- end }}
+{{- end }}
+
+## <<Stencil::Block(customMiseEnvironment)>>
+{{ file.Block "customMiseEnvironment" }}
+## <</Stencil::Block>>
+
+[tools]
+"npm:prettier" = "2"
+
+{{- range $_, $toolMap := stencil.GetModuleHook "miseTools" }}
+{{- range $name, $tool := $toolMap }}
+{{ $name | quote }} = {{ $tool | toTOML }}
+{{- end }}
+{{- end }}
+
+## <<Stencil::Block(customMiseTools)>>
+{{ file.Block "customMiseTools" }}
+## <</Stencil::Block>>
+
+## <<Stencil::Block(extraMise)>>
+{{ file.Block "extraMise" }}
+## <</Stencil::Block>>

--- a/templates/package.json.tpl
+++ b/templates/package.json.tpl
@@ -14,7 +14,6 @@
 {{- range stencil.GetModuleHook "nodejs_dependencies" }}
     "{{ .name }}": "{{ .version }}",
 {{- end }}
-    "prettier": "^2.8.8",
     "semantic-release": "^23.0.8",
     "semver": "^7.6.0"
   }


### PR DESCRIPTION
## What this PR does / why we need it

Start migrating everything to `mise` in the Stencil templates by providing a base file in this Stencil module.

Also, move the `prettier` dependency from `package.json` to `mise` to make it easier to render the `tools` section.

## Jira ID

[DT-4797]