### PR TITLE
fix(mise): always emit env section

### DIFF
--- a/templates/.snapshots/TestRenderMiseTOML-mise.toml.tpl-mise.toml.snapshot
+++ b/templates/.snapshots/TestRenderMiseTOML-mise.toml.tpl-mise.toml.snapshot
@@ -1,6 +1,8 @@
 (*codegen.File)([task_config]
 includes = [".bootstrap/.mise/tasks"]
 
+[env]
+
 ## <<Stencil::Block(customMiseEnvironment)>>
 
 ## <</Stencil::Block>>

--- a/templates/mise.toml.tpl
+++ b/templates/mise.toml.tpl
@@ -1,12 +1,9 @@
 [task_config]
 includes = [".bootstrap/.mise/tasks"]
 
-{{- $miseEnvironments := stencil.GetModuleHook "miseEnvironment" }}
-{{- if gt ($miseEnvironments | len) 0 }}
 [env]
-{{- range $miseEnvironments }}
+{{- range (stencil.GetModuleHook "miseEnvironment") }}
 {{ . | toToml }}
-{{- end }}
 {{- end }}
 
 ## <<Stencil::Block(customMiseEnvironment)>>


### PR DESCRIPTION
## What this PR does / why we need it

Otherwise the `customMiseEnvironment` block doesn't make sense. It appears that an empty `[env]` section is fine with `mise`.