### PR TITLE
fix(postrun): always run `yarn`, conditionally run `yarn upgrade`

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -20,7 +20,7 @@ postRunCommand:
   - name: go mod tidy
     command: go mod tidy -compat=1.17
   - name: Install or upgrade release-related Node.js packages
-    command: if test -f yarn.lock; then yarn upgrade; else yarn; fi
+    command: yarn; if test -f yarn.lock; then yarn upgrade; fi
 arguments:
   releaseOptions.enablePrereleases:
     description: Enable prereleases


### PR DESCRIPTION
## What this PR does / why we need it

This should take care of adding/removing direct dependencies, as `yarn upgrade` fails without it.