### PR TITLE
feat(README): replace hardcoded service activity descriptions with a module hook

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -52,15 +52,6 @@ arguments:
     schema:
       type: boolean
     description: Whether or not this application is a runnable service. This flag provides the service activity interface and everything necessary for releasing and deploying a service.
-  serviceActivities:
-    schema:
-      type: array
-      items:
-        type: string
-    description: |-
-      Any valid built-in service activities can be supplied here and they will be provided.
-      The `service` flag must be set to true. See 'stencil-golang' for valid values, this will eventually be removed
-      from `stencil-base` as it's not meant to be used here.
   reportingTeam:
     required: true
     schema:

--- a/templates/README.md.tpl
+++ b/templates/README.md.tpl
@@ -28,7 +28,7 @@ Please read the [CONTRIBUTING.md](CONTRIBUTING.md) document for guidelines on de
 ## Dependencies
 
 {{- if not (stencil.Arg "oss") }}
-Make sure you've ran `orc setup`.
+Make sure you have run `orc setup` recently.
 {{- end }}
 
 ### Dependencies

--- a/templates/README.md.tpl
+++ b/templates/README.md.tpl
@@ -73,3 +73,4 @@ devenv apps delete {{ .Config.Name }}
 
 {{- end }}
 {{- end }}
+{{- end }}

--- a/templates/README.md.tpl
+++ b/templates/README.md.tpl
@@ -45,7 +45,9 @@ Make sure you have run `orc setup` recently.
 {{- range (stencil.Arg "dependencies.optional") }}
 * {{ . }}
 {{- end }}
-{{- end}}
+{{- end }}
+
+{{- if (stencil.Arg "service") }}
 
 ### Adding and Deleting Service in Development Environment
 
@@ -61,54 +63,13 @@ To delete this service from your developer environment:
 devenv apps delete {{ .Config.Name }}
 ```
 
-{{- if (stencil.Arg "service") }}
+{{- $serviceActivityDescriptions := stencil.GetModuleHook "serviceActivityDescriptions" }}
+{{- if not (empty $serviceActivityDescriptions) }}
 ## Interacting with {{ title (.Config.Name) }}
 
-{{- if has "grpc" (stencil.Arg "serviceActivities") }}
-### via gRPC
-
-[grpcui](https://github.com/fullstorydev/grpcui) can be useful for talking to {{ .Config.Name }} locally. To run it:
-
-```bash
-make grpcui
-```
+{{- range $serviceActivityDescriptions }}
+{{ . }}
 {{- end }}
 
-{{- if has "http" (stencil.Arg "serviceActivities") }}
-### via HTTP
-
-There are two different HTTP servers running by default on stencil services, a public (external) and a private
-(internal) server. By default, the port for the public server is `8080`, and the port for the private server is `8000`.
-These are subject to change, and if they are changed, those changes should be reflected in
-`deployments/{{ .Config.Name }}/{{ .Config.Name }}.config.jsonnet`.
-
-If the service is running locally either through running `make devserver` or running the binary directly, you can
-interact with these servers over `localhost` or `127.0.0.1` using the appropriate port.
-
-If the service is running in kubernetes you'll either have to launch an alpine pod into the namespace and interact with
-the HTTP servers using cURL (make sure to `apk add curl` in the alpine container) or you can port-forward to get access
-to them on your local network:
-
-```bash
-devenv kubectl -n {{ .Config.Name }}--bento1a port-forward service/{{ .Config.Name }} <port>
-```
-
-Where port is either the port for the public or private HTTP server.
-{{- end }}
-
-{{- if has "clerk" (stencil.Arg "serviceActivities") }}
-### via Clerk
-
-The clerk field in service.yaml generates stubs to communicate with clerk. Using this a service can produce and consume
-clerk messages to and from kafka. For more details on how this works, please click
-[here](https://outreach-io.atlassian.net/wiki/spaces/DP/pages/2290876556/clerk+bootstrap+integration).
-{{- end }}
-
-{{- if has "temporal" (stencil.Arg "serviceActivities") }}
-### via Temporal
-
-See the [temporal documentation](./documentation/temporal.md) for info on managing and interacting with temporal.
-
-{{- end }}
 {{- end }}
 {{- end }}

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -1,5 +1,0 @@
-{{- file.Skip "Virtual file with functions" }}
-
-{{- if and (not (stencil.Arg "service")) (not (empty (stencil.Arg "serviceActivities"))) }}
-{{ fail "service has to be set to \"true\" in order to supply \"serviceActivities\"" }}
-{{- end }}

--- a/templates/main_test.go
+++ b/templates/main_test.go
@@ -8,13 +8,13 @@ import (
 
 // Replace this with your own tests.
 func TestRenderAFile(t *testing.T) {
-	st := stenciltest.New(t, ".releaserc.yaml.tpl", "_helpers.tpl")
+	st := stenciltest.New(t, ".releaserc.yaml.tpl")
 	st.Args(map[string]any{})
 	st.Run(stenciltest.RegenerateSnapshots())
 }
 
 func TestRenderReadmeFile(t *testing.T) {
-	st := stenciltest.New(t, "README.md.tpl", "_helpers.tpl")
+	st := stenciltest.New(t, "README.md.tpl")
 	st.Args(map[string]any{
 		"description": "My service",
 	})
@@ -22,13 +22,13 @@ func TestRenderReadmeFile(t *testing.T) {
 }
 
 func TestRenderPullRequestTemplateFile(t *testing.T) {
-	st := stenciltest.New(t, ".github/pull_request_template.md.tpl", "_helpers.tpl")
+	st := stenciltest.New(t, ".github/pull_request_template.md.tpl")
 	st.Args(map[string]any{})
 	st.Run(stenciltest.RegenerateSnapshots())
 }
 
 func TestRenderCodeownersFile(t *testing.T) {
-	st := stenciltest.New(t, ".github/CODEOWNERS.tpl", "_helpers.tpl")
+	st := stenciltest.New(t, ".github/CODEOWNERS.tpl")
 	st.Args(map[string]any{
 		"reportingTeam": "foo-bar",
 	})
@@ -36,7 +36,7 @@ func TestRenderCodeownersFile(t *testing.T) {
 }
 
 func TestRenderCodeownersWithExtraOwnersFile(t *testing.T) {
-	st := stenciltest.New(t, ".github/CODEOWNERS.tpl", "_helpers.tpl")
+	st := stenciltest.New(t, ".github/CODEOWNERS.tpl")
 	st.Args(map[string]any{
 		"reportingTeam": "foo-bar",
 		"additionalRepoOwners": []any{
@@ -48,12 +48,12 @@ func TestRenderCodeownersWithExtraOwnersFile(t *testing.T) {
 }
 
 func TestRenderPackageJSON(t *testing.T) {
-	st := stenciltest.New(t, "package.json.tpl", "_helpers.tpl")
+	st := stenciltest.New(t, "package.json.tpl")
 	st.Run(stenciltest.RegenerateSnapshots())
 }
 
 func TestRenderPackageJSONWithoutReleases(t *testing.T) {
-	st := stenciltest.New(t, "package.json.tpl", "_helpers.tpl")
+	st := stenciltest.New(t, "package.json.tpl")
 	st.Args(map[string]any{
 		"releaseOptions": map[string]any{
 			"enabled": false,
@@ -63,13 +63,13 @@ func TestRenderPackageJSONWithoutReleases(t *testing.T) {
 }
 
 func TestRenderMiseTOML(t *testing.T) {
-	st := stenciltest.New(t, "mise.toml.tpl", "_helpers.tpl")
+	st := stenciltest.New(t, "mise.toml.tpl")
 	st.Args(map[string]any{})
 	st.Run(stenciltest.RegenerateSnapshots())
 }
 
 func TestRenderMiseTOMLWithNewerHardMinMiseVersion(t *testing.T) {
-	st := stenciltest.New(t, "mise.toml.tpl", "_helpers.tpl")
+	st := stenciltest.New(t, "mise.toml.tpl")
 	st.Args(map[string]any{
 		"versions": map[string]any{
 			"mise": map[string]any{
@@ -81,7 +81,7 @@ func TestRenderMiseTOMLWithNewerHardMinMiseVersion(t *testing.T) {
 }
 
 func TestRenderMiseTOMLWithOlderHardMinMiseVersion(t *testing.T) {
-	st := stenciltest.New(t, "mise.toml.tpl", "_helpers.tpl")
+	st := stenciltest.New(t, "mise.toml.tpl")
 	st.Args(map[string]any{
 		"versions": map[string]any{
 			"mise": map[string]any{
@@ -93,7 +93,7 @@ func TestRenderMiseTOMLWithOlderHardMinMiseVersion(t *testing.T) {
 }
 
 func TestRenderMiseTOMLWithInvalidHardMinMiseVersion(t *testing.T) {
-	st := stenciltest.New(t, "mise.toml.tpl", "_helpers.tpl")
+	st := stenciltest.New(t, "mise.toml.tpl")
 	st.Args(map[string]any{
 		"versions": map[string]any{
 			"mise": map[string]any{


### PR DESCRIPTION
## What this PR does / why we need it

This removes the awkward `serviceActivities` argument from this module (it really lives in `stencil-golang`).

## Jira ID

[DT-5187]

[DT-5187]: https://outreach-io.atlassian.net/browse/DT-5187?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ